### PR TITLE
Add notes and nickname to add command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -5,6 +5,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NICKNAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTES;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
@@ -27,6 +29,9 @@ public class AddCommand extends Command {
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
+            + "[" + PREFIX_BIRTHDAY + "BIRTHDAY] "
+            + "[" + PREFIX_NICKNAME + "NICKNAME] "
+            + "[" + PREFIX_NOTES + "NOTES] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
@@ -34,6 +39,8 @@ public class AddCommand extends Command {
             + PREFIX_EMAIL + "johnd@example.com "
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
             + PREFIX_BIRTHDAY + "30-12-2001 "
+            + PREFIX_NICKNAME + "Johnny "
+            + PREFIX_NOTES + "Allergic to peanuts "
             + PREFIX_TAG + "friends "
             + PREFIX_TAG + "owesMoney";
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -5,6 +5,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NICKNAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTES;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
@@ -26,6 +28,8 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.Birthday;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.Nickname;
+import seedu.address.model.person.Notes;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
@@ -46,6 +50,8 @@ public class EditCommand extends Command {
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
             + "[" + PREFIX_BIRTHDAY + "BIRTHDAY]"
+            + "[" + PREFIX_NICKNAME + "NICKNAME]"
+            + "[" + PREFIX_NOTES + "NOTES]"
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
@@ -102,12 +108,17 @@ public class EditCommand extends Command {
         Phone updatedPhone = editPersonDescriptor.getPhone().orElse(personToEdit.getPhone());
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
-        Optional<Birthday> updatedBirthday = editPersonDescriptor.getBirthday();
+        Optional<Birthday> updatedBirthday = editPersonDescriptor.getBirthday().isPresent()
+                ? editPersonDescriptor.getBirthday() : personToEdit.getBirthday();
+        Optional<Nickname> updatedNickname = editPersonDescriptor.getNickname().isPresent()
+                ? editPersonDescriptor.getNickname() : personToEdit.getNickname();
+        Optional<Notes> updatedNotes = editPersonDescriptor.getNotes().isPresent()
+                ? editPersonDescriptor.getNotes() : personToEdit.getNotes();
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
 
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedBirthday, updatedTags);
+        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedBirthday,
+                updatedNickname, updatedNotes, updatedTags);
     }
-
     @Override
     public boolean equals(Object other) {
         if (other == this) {
@@ -142,6 +153,8 @@ public class EditCommand extends Command {
         private Email email;
         private Address address;
         private Optional<Birthday> birthday;
+        private Optional<Nickname> nickname;
+        private Optional<Notes> notes;
         private Set<Tag> tags;
 
         public EditPersonDescriptor() {}
@@ -156,6 +169,8 @@ public class EditCommand extends Command {
             setEmail(toCopy.email);
             setAddress(toCopy.address);
             setBirthday(toCopy.birthday);
+            setNickname(toCopy.nickname);
+            setNotes(toCopy.notes);
             setTags(toCopy.tags);
         }
 
@@ -163,7 +178,7 @@ public class EditCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, phone, email, address, tags);
+            return CollectionUtil.isAnyNonNull(name, phone, email, address, birthday, nickname, notes, tags);
         }
 
         public void setName(Name name) {
@@ -197,6 +212,12 @@ public class EditCommand extends Command {
         public void setBirthday(Optional<Birthday> birthday) {
             this.birthday = birthday;
         }
+        public void setNickname(Optional<Nickname> nickname) {
+            this.nickname = nickname;
+        }
+        public void setNotes(Optional<Notes> notes) {
+            this.notes = notes;
+        }
 
         public Optional<Address> getAddress() {
             return Optional.ofNullable(address);
@@ -204,6 +225,14 @@ public class EditCommand extends Command {
 
         public Optional<Birthday> getBirthday() {
             return Optional.ofNullable(birthday).flatMap(b -> b);
+        }
+
+        public Optional<Nickname> getNickname() {
+            return Optional.ofNullable(nickname).flatMap(b -> b);
+        }
+
+        public Optional<Notes> getNotes() {
+            return Optional.ofNullable(notes).flatMap(b -> b);
         }
 
         /**
@@ -240,6 +269,8 @@ public class EditCommand extends Command {
                     && Objects.equals(email, otherEditPersonDescriptor.email)
                     && Objects.equals(address, otherEditPersonDescriptor.address)
                     && Objects.equals(birthday, otherEditPersonDescriptor.birthday)
+                    && Objects.equals(nickname, otherEditPersonDescriptor.nickname)
+                    && Objects.equals(notes, otherEditPersonDescriptor.notes)
                     && Objects.equals(tags, otherEditPersonDescriptor.tags);
         }
 
@@ -251,6 +282,8 @@ public class EditCommand extends Command {
                     .add("email", email)
                     .add("address", address)
                     .add("birthday", birthday)
+                    .add("nickname", nickname)
+                    .add("notes", notes)
                     .add("tags", tags)
                     .toString();
         }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -5,6 +5,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NICKNAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTES;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
@@ -18,6 +20,8 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.Birthday;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.Nickname;
+import seedu.address.model.person.Notes;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
@@ -35,7 +39,7 @@ public class AddCommandParser implements Parser<AddCommand> {
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
-                        PREFIX_BIRTHDAY, PREFIX_TAG);
+                        PREFIX_BIRTHDAY, PREFIX_NICKNAME, PREFIX_NOTES, PREFIX_TAG);
         System.out.println(argMultimap);
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL)
                 || !argMultimap.getPreamble().isEmpty()) {
@@ -43,15 +47,17 @@ public class AddCommandParser implements Parser<AddCommand> {
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
-                PREFIX_BIRTHDAY);
+                PREFIX_BIRTHDAY, PREFIX_NICKNAME, PREFIX_NOTES);
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
         Optional<Birthday> birthday = ParserUtil.parseBirthday(argMultimap.getValue(PREFIX_BIRTHDAY));
+        Optional<Nickname> nickname = ParserUtil.parseNickname(argMultimap.getValue(PREFIX_NICKNAME));
+        Optional<Notes> notes = ParserUtil.parseNotes(argMultimap.getValue(PREFIX_NOTES));
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-        Person person = new Person(name, phone, email, address, birthday, tagList);
+        Person person = new Person(name, phone, email, address, birthday, nickname, notes, tagList);
         return new AddCommand(person);
     }
 

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -12,5 +12,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_BIRTHDAY = new Prefix("b/");
-
+    public static final Prefix PREFIX_NICKNAME = new Prefix("nn/");
+    public static final Prefix PREFIX_NOTES = new Prefix("no/");
 }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -6,6 +6,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NICKNAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTES;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
@@ -34,7 +36,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
-                        PREFIX_BIRTHDAY, PREFIX_TAG);
+                        PREFIX_BIRTHDAY, PREFIX_NICKNAME, PREFIX_NOTES, PREFIX_TAG);
 
         Index index;
 
@@ -45,7 +47,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
-                PREFIX_BIRTHDAY);
+                PREFIX_BIRTHDAY, PREFIX_NICKNAME, PREFIX_NOTES);
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
 
@@ -63,6 +65,12 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
         if (argMultimap.getValue(PREFIX_BIRTHDAY).isPresent()) {
             editPersonDescriptor.setBirthday(ParserUtil.parseBirthday(argMultimap.getValue(PREFIX_BIRTHDAY)));
+        }
+        if (argMultimap.getValue(PREFIX_NICKNAME).isPresent()) {
+            editPersonDescriptor.setNickname(ParserUtil.parseNickname(argMultimap.getValue(PREFIX_NICKNAME)));
+        }
+        if (argMultimap.getValue(PREFIX_NOTES).isPresent()) {
+            editPersonDescriptor.setNotes(ParserUtil.parseNotes(argMultimap.getValue(PREFIX_NOTES)));
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -14,6 +14,8 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.Birthday;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.Nickname;
+import seedu.address.model.person.Notes;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 
@@ -102,6 +104,48 @@ public class ParserUtil {
             throw new ParseException(e.getMessage());
         }
         return Optional.of(new Birthday(trimmedBirthday));
+    }
+
+    /**
+     * Parses a {@code String nickname} into a {@code Nickname}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @param nickname The input string representing the nickname.
+     * @return A {@code Nickname} object if the input string is valid.
+     * @throws ParseException If the given {@code nickname} is invalid.
+     */
+    public static Optional<Nickname> parseNickname(Optional<String> nickname) throws ParseException {
+        if (nickname.isEmpty()) {
+            return Optional.empty();
+        }
+        String trimmedNickname = nickname.get().trim();
+        try {
+            Nickname.isValidNickname(trimmedNickname);
+        } catch (IllegalArgumentException e) {
+            throw new ParseException(e.getMessage());
+        }
+        return Optional.of(new Nickname(trimmedNickname));
+    }
+
+    /**
+     * Parses a {@code String notes} into a {@code Notes}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @param notes The input string representing the notes.
+     * @return A {@code Notes} object if the input string is valid.
+     * @throws ParseException If the given {@code notes} is invalid.
+     */
+    public static Optional<Notes> parseNotes(Optional<String> notes) throws ParseException {
+        if (notes.isEmpty()) {
+            return Optional.empty();
+        }
+        String trimmedNotes = notes.get().trim();
+        try {
+            Notes.isValidNotes(trimmedNotes);
+        } catch (IllegalArgumentException e) {
+            throw new ParseException(e.getMessage());
+        }
+        return Optional.of(new Notes(trimmedNotes));
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Nickname.java
+++ b/src/main/java/seedu/address/model/person/Nickname.java
@@ -1,24 +1,19 @@
 package seedu.address.model.person;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
  * Represents a Person's nickname in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidNickname(String)}
  */
 public class Nickname {
+    public static final String MESSAGE_CONSTRAINTS_LENGTH =
+            "Nicknames should be less than 30 characters long";
+    public static final String MESSAGE_CONSTRAINTS_CHARACTERS =
+            "Nicknames can only contain printable ASCII characters";
 
-    public static final String MESSAGE_CONSTRAINTS =
-            "Nicknames should be less than 30 characters long and can contain letters, numbers, "
-                    + "spaces and the following special characters: .,'!@#&()-_+=";
-
-    /*
-     * The first character of the nickname must not be a whitespace,
-     * otherwise " " (a blank string) becomes a valid input.
-     */
     public static final int MAX_LENGTH = 30;
-    public static final String VALIDATION_REGEX = "^(?!\\s)[\\p{L}\\p{N} .,'!@#&()-_+=]*$";
+    public static final String VALIDATION_REGEX = "[^\\s].*";
 
     public final String nickname;
 
@@ -29,15 +24,21 @@ public class Nickname {
      */
     public Nickname(String nickname) {
         requireNonNull(nickname);
-        checkArgument(isValidNickname(nickname), MESSAGE_CONSTRAINTS);
+        isValidNickname(nickname);
         this.nickname = nickname;
     }
 
     /**
-     * Returns true if a given string is a valid nickname.
+     * Validates the nickname and throws an IllegalArgumentException with a specific message if invalid.
      */
     public static boolean isValidNickname(String test) {
-        return test.matches(VALIDATION_REGEX) && test.length() <= MAX_LENGTH;
+        if (!test.matches(VALIDATION_REGEX)) {
+            throw new IllegalArgumentException(MESSAGE_CONSTRAINTS_CHARACTERS);
+        }
+        if (test.length() > MAX_LENGTH) {
+            throw new IllegalArgumentException(MESSAGE_CONSTRAINTS_LENGTH);
+        }
+        return true;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Nickname.java
+++ b/src/main/java/seedu/address/model/person/Nickname.java
@@ -1,0 +1,67 @@
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a Person's nickname in the address book.
+ * Guarantees: immutable; is valid as declared in {@link #isValidNickname(String)}
+ */
+public class Nickname {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Nicknames should be less than 30 characters long and can contain letters, numbers, "
+                    + "spaces and the following special characters: .,'!@#&()-_+=";
+
+    /*
+     * The first character of the nickname must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     */
+    public static final int MAX_LENGTH = 30;
+    public static final String VALIDATION_REGEX = "^(?!\\s)[\\p{L}\\p{N} .,'!@#&()-_+=]*$";
+
+    public final String nickname;
+
+    /**
+     * Constructs a {@code Nickname}.
+     *
+     * @param nickname A valid nickname.
+     */
+    public Nickname(String nickname) {
+        requireNonNull(nickname);
+        checkArgument(isValidNickname(nickname), MESSAGE_CONSTRAINTS);
+        this.nickname = nickname;
+    }
+
+    /**
+     * Returns true if a given string is a valid nickname.
+     */
+    public static boolean isValidNickname(String test) {
+        return test.matches(VALIDATION_REGEX) && test.length() <= MAX_LENGTH;
+    }
+
+    @Override
+    public String toString() {
+        return nickname;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof Nickname)) {
+            return false;
+        }
+
+        Nickname otherNickname = (Nickname) other;
+        return nickname.equals(otherNickname.nickname);
+    }
+
+    @Override
+    public int hashCode() {
+        return nickname.hashCode();
+    }
+}

--- a/src/main/java/seedu/address/model/person/Notes.java
+++ b/src/main/java/seedu/address/model/person/Notes.java
@@ -23,23 +23,8 @@ public class Notes {
      */
     public Notes(String notes) {
         requireNonNull(notes);
-        validateNotes(notes);
+        isValidNotes(notes);
         this.value = notes;
-    }
-
-    /**
-     * Validates notes and throws exceptions with specific messages if invalid.
-     */
-    private static void validateNotes(String test) {
-        if (test.isEmpty()) {
-            return;
-        }
-        if (test.length() > MAX_LENGTH) {
-            throw new IllegalArgumentException(MESSAGE_CONSTRAINTS_LENGTH);
-        }
-        if (!test.matches(VALIDATION_REGEX)) {
-            throw new IllegalArgumentException(MESSAGE_CONSTRAINTS_CHARACTERS);
-        }
     }
 
     /**
@@ -50,8 +35,13 @@ public class Notes {
         if (test.isEmpty()) {
             return true;
         }
-
-        return test.matches(VALIDATION_REGEX) && test.length() <= MAX_LENGTH;
+        if (test.length() > MAX_LENGTH) {
+            throw new IllegalArgumentException(MESSAGE_CONSTRAINTS_LENGTH);
+        }
+        if (!test.matches(VALIDATION_REGEX)) {
+            throw new IllegalArgumentException(MESSAGE_CONSTRAINTS_CHARACTERS);
+        }
+        return true;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Notes.java
+++ b/src/main/java/seedu/address/model/person/Notes.java
@@ -1,23 +1,16 @@
 package seedu.address.model.person;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
  * Represents a Person's notes in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidNotes(String)}
  */
 public class Notes {
-
-    public static final String MESSAGE_CONSTRAINTS =
-            "Notes should only contain printable characters, not start with whitespace, and be at most"
-                    + " 100 characters long";
-
-    /*
-     * The first character of the notes must not be a whitespace,
-     * otherwise " " (a blank string) becomes a valid input.
-     * Since notes can contain various characters including punctuation, we use a more permissive regex.
-     */
+    public static final String MESSAGE_CONSTRAINTS_LENGTH =
+            "Notes can be at most 100 characters long";
+    public static final String MESSAGE_CONSTRAINTS_CHARACTERS =
+            "Notes should only contain printable characters";
     public static final String VALIDATION_REGEX = "[^\\s].*";
     public static final int MAX_LENGTH = 100;
 
@@ -30,8 +23,23 @@ public class Notes {
      */
     public Notes(String notes) {
         requireNonNull(notes);
-        checkArgument(isValidNotes(notes), MESSAGE_CONSTRAINTS);
+        validateNotes(notes);
         this.value = notes;
+    }
+
+    /**
+     * Validates notes and throws exceptions with specific messages if invalid.
+     */
+    private static void validateNotes(String test) {
+        if (test.isEmpty()) {
+            return;
+        }
+        if (test.length() > MAX_LENGTH) {
+            throw new IllegalArgumentException(MESSAGE_CONSTRAINTS_LENGTH);
+        }
+        if (!test.matches(VALIDATION_REGEX)) {
+            throw new IllegalArgumentException(MESSAGE_CONSTRAINTS_CHARACTERS);
+        }
     }
 
     /**
@@ -42,6 +50,7 @@ public class Notes {
         if (test.isEmpty()) {
             return true;
         }
+
         return test.matches(VALIDATION_REGEX) && test.length() <= MAX_LENGTH;
     }
 

--- a/src/main/java/seedu/address/model/person/Notes.java
+++ b/src/main/java/seedu/address/model/person/Notes.java
@@ -1,0 +1,72 @@
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a Person's notes in the address book.
+ * Guarantees: immutable; is valid as declared in {@link #isValidNotes(String)}
+ */
+public class Notes {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Notes should only contain printable characters, not start with whitespace, and be at most"
+                    + " 100 characters long";
+
+    /*
+     * The first character of the notes must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     * Since notes can contain various characters including punctuation, we use a more permissive regex.
+     */
+    public static final String VALIDATION_REGEX = "[^\\s].*";
+    public static final int MAX_LENGTH = 100;
+
+    public final String value;
+
+    /**
+     * Constructs a {@code Notes}.
+     *
+     * @param notes A valid notes string.
+     */
+    public Notes(String notes) {
+        requireNonNull(notes);
+        checkArgument(isValidNotes(notes), MESSAGE_CONSTRAINTS);
+        this.value = notes;
+    }
+
+    /**
+     * Returns true if a given string is valid notes.
+     * Empty string is considered valid as notes are optional.
+     */
+    public static boolean isValidNotes(String test) {
+        if (test.isEmpty()) {
+            return true;
+        }
+        return test.matches(VALIDATION_REGEX) && test.length() <= MAX_LENGTH;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof Notes)) {
+            return false;
+        }
+
+        Notes otherNotes = (Notes) other;
+        return value.equals(otherNotes.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+}

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -25,19 +25,24 @@ public class Person {
     // Data fields
     private final Address address;
     private final Optional<Birthday> birthday;
+    private final Optional<Nickname> nickname;
+    private final Optional<Notes> notes;
 
     private final Set<Tag> tags = new HashSet<>();
 
     /**
      * Every field must be present and not null.
      */
-    public Person(Name name, Phone phone, Email email, Address address, Optional<Birthday> birthday, Set<Tag> tags) {
+    public Person(Name name, Phone phone, Email email, Address address, Optional<Birthday> birthday,
+                  Optional<Nickname> nickname, Optional<Notes> notes, Set<Tag> tags) {
         requireAllNonNull(name, phone, email, address, tags);
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.address = address;
         this.birthday = birthday != null ? birthday : Optional.empty();
+        this.nickname = nickname;
+        this.notes = notes;
         this.tags.addAll(tags);
     }
 
@@ -59,6 +64,12 @@ public class Person {
 
     public Optional<Birthday> getBirthday() {
         return birthday;
+    }
+    public Optional<Nickname> getNickname() {
+        return nickname;
+    }
+    public Optional<Notes> getNotes() {
+        return notes;
     }
 
     /**
@@ -103,13 +114,15 @@ public class Person {
                 && email.equals(otherPerson.email)
                 && address.equals(otherPerson.address)
                 && birthday.equals(otherPerson.birthday)
+                && nickname.equals(otherPerson.nickname)
+                && notes.equals(otherPerson.notes)
                 && tags.equals(otherPerson.tags);
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, address, birthday, tags);
+        return Objects.hash(name, phone, email, address, birthday, nickname, notes, tags);
     }
 
     @Override
@@ -120,6 +133,8 @@ public class Person {
                 .add("email", email)
                 .add("address", address)
                 .add("birthday", birthday)
+                .add("nickname", nickname)
+                .add("notes", notes)
                 .add("tags", tags)
                 .toString();
     }

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -11,6 +11,8 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.Birthday;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.Nickname;
+import seedu.address.model.person.Notes;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
@@ -22,23 +24,29 @@ public class SampleDataUtil {
     public static Person[] getSamplePersons() {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
-                new Address("Blk 30 Geylang Street 29, #06-40"), Optional.of(new Birthday("01-01-1990")),
-                getTagSet("friends")),
+                    new Address("Blk 30 Geylang Street 29, #06-40"), Optional.of(new Birthday("01-01-1990")),
+                    Optional.of(new Nickname("Al")), Optional.of(new Notes("Likes photography")),
+                    getTagSet("friends")),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
-                new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), Optional.of(new Birthday("01-01-1990")),
-                getTagSet("colleagues", "friends")),
+                    new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), Optional.of(new Birthday("15-03-1992")),
+                    Optional.of(new Nickname("Bernie")), Optional.empty(),
+                    getTagSet("colleagues", "friends")),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
-                new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), Optional.of(new Birthday("01-01-1990")),
-                getTagSet("neighbours")),
+                    new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), Optional.of(new Birthday("22-07-1995")),
+                    Optional.empty(), Optional.of(new Notes("Allergic to peanuts")),
+                    getTagSet("neighbours")),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
-                new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), Optional.of(new Birthday("01-01-1990")),
-                getTagSet("family")),
+                    new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), Optional.of(new Birthday("30-12-1989")),
+                    Optional.of(new Nickname("Dave")), Optional.of(new Notes("Prefers email contact")),
+                    getTagSet("family")),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
-                new Address("Blk 47 Tampines Street 20, #17-35"), Optional.of(new Birthday("01-01-1990")),
-                getTagSet("classmates")),
+                    new Address("Blk 47 Tampines Street 20, #17-35"), Optional.of(new Birthday("05-09-1993")),
+                    Optional.empty(), Optional.empty(),
+                    getTagSet("classmates")),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
-                new Address("Blk 45 Aljunied Street 85, #11-31"), Optional.of(new Birthday("01-01-1990")),
-                getTagSet("colleagues"))
+                    new Address("Blk 45 Aljunied Street 85, #11-31"), Optional.of(new Birthday("12-06-1988")),
+                    Optional.of(new Nickname("RB")), Optional.of(new Notes("Birthday gift idea: books")),
+                    getTagSet("colleagues"))
         };
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -15,6 +15,8 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.Birthday;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.Nickname;
+import seedu.address.model.person.Notes;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
@@ -31,6 +33,8 @@ class JsonAdaptedPerson {
     private final String email;
     private final String address;
     private final String birthday;
+    private final String nickname;
+    private final String notes;
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
 
     /**
@@ -39,12 +43,15 @@ class JsonAdaptedPerson {
     @JsonCreator
     public JsonAdaptedPerson(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
             @JsonProperty("email") String email, @JsonProperty("address") String address,
-                @JsonProperty("birthday") String birthday, @JsonProperty("tags") List<JsonAdaptedTag> tags) {
+                @JsonProperty("birthday") String birthday, @JsonProperty("nickname") String nickname,
+                             @JsonProperty("notes") String notes, @JsonProperty("tags") List<JsonAdaptedTag> tags) {
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.address = address;
         this.birthday = birthday;
+        this.nickname = nickname;
+        this.notes = notes;
         if (tags != null) {
             this.tags.addAll(tags);
         }
@@ -59,6 +66,8 @@ class JsonAdaptedPerson {
         email = source.getEmail().value;
         address = source.getAddress().value;
         birthday = source.getBirthday().map(b -> b.value).orElse("");
+        nickname = source.getNickname().map(Nickname::toString).orElse("");
+        notes = source.getNotes().map(Notes::toString).orElse("");
         tags.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
@@ -108,7 +117,6 @@ class JsonAdaptedPerson {
 
         final Address modelAddress = new Address(address);
 
-
         final Optional<Birthday> modelBirthday;
         if (birthday == null || birthday.isEmpty()) {
             modelBirthday = Optional.empty();
@@ -120,8 +128,31 @@ class JsonAdaptedPerson {
             }
         }
 
+        final Optional<Nickname> modelNickname;
+        if (nickname == null || nickname.isEmpty()) {
+            modelNickname = Optional.empty();
+        } else {
+            try {
+                modelNickname = Optional.of(new Nickname(nickname));
+            } catch (IllegalArgumentException e) {
+                throw new IllegalValueException(e.getMessage());
+            }
+        }
+
+        final Optional<Notes> modelNotes;
+        if (notes == null || notes.isEmpty()) {
+            modelNotes = Optional.empty();
+        } else {
+            try {
+                modelNotes = Optional.of(new Notes(notes));
+            } catch (IllegalArgumentException e) {
+                throw new IllegalValueException(e.getMessage());
+            }
+        }
+
         final Set<Tag> modelTags = new HashSet<>(personTags);
-        return new Person(modelName, modelPhone, modelEmail, modelAddress, modelBirthday, modelTags);
+        return new Person(modelName, modelPhone, modelEmail, modelAddress, modelBirthday, modelNickname,
+                modelNotes, modelTags);
     }
 
 }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -8,6 +8,8 @@ import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.address.model.person.Birthday;
+import seedu.address.model.person.Nickname;
+import seedu.address.model.person.Notes;
 import seedu.address.model.person.Person;
 
 /**
@@ -42,6 +44,10 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private Label birthday;
     @FXML
+    private Label nickname;
+    @FXML
+    private Label notes;
+    @FXML
     private FlowPane tags;
 
     /**
@@ -56,6 +62,8 @@ public class PersonCard extends UiPart<Region> {
         address.setText(person.getAddress().value);
         email.setText(person.getEmail().value);
         birthday.setText(person.getBirthday().map(Birthday::getBirthdayStringFormatted).orElse(""));
+        nickname.setText(person.getNickname().map(Nickname::toString).orElse(""));
+        notes.setText(person.getNotes().map(Notes::toString).orElse(""));
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -32,6 +32,8 @@
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
       <Label fx:id="birthday" styleClass="cell_small_label" text="\$birthday" />
+      <Label fx:id="nickname" styleClass="cell_small_label" text="\$nickname" />
+      <Label fx:id="notes" styleClass="cell_small_label" text="\$notes" />
     </VBox>
   </GridPane>
 </HBox>

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -11,6 +11,9 @@
     "phone" : "98765432",
     "email" : "johnd@example.com",
     "address" : "311, Clementi Ave 2, #02-25",
+    "birthday" : "01-01-1990",
+    "nickname" : "BENNY",
+    "notes" : "Allergic to peanuts",
     "tags" : [ "owesMoney", "friends" ]
   }, {
     "name" : "Carl Kurz",

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NICKNAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTES;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -34,6 +36,8 @@ public class CommandTestUtil {
     public static final String VALID_EMAIL_BOB = "bob@example.com";
     public static final String VALID_ADDRESS_AMY = "Block 312, Amy Street 1";
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
+    public static final String VALID_NICKNAME_BOB = "Uncle Bobby";
+    public static final String VALID_NOTES_BOB = "Allergic to peanuts";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
 
@@ -53,6 +57,11 @@ public class CommandTestUtil {
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
+    public static final String INVALID_NICKNAME_LENGTH_DESC = " " + PREFIX_NICKNAME
+            + "ThisNicknameIsWayTooLongAndExceedsTheMaximumLengthOfThirtyCharacters"; // exceeds 30 chars
+    public static final String INVALID_NOTES_LENGTH_DESC = " " + PREFIX_NOTES
+            + "This notes text is much too long and exceeds the maximum allowed length of one hundred characters "
+            + "which will cause validation to fail"; // exceeds 100 chars
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NICKNAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NOTES_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
@@ -60,6 +62,44 @@ public class EditCommandTest {
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withTags(VALID_TAG_HUSBAND).build();
+        EditCommand editCommand = new EditCommand(indexLastPerson, descriptor);
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(lastPerson, editedPerson);
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_editNicknameUnfilteredList_success() {
+        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
+        Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
+
+        PersonBuilder personInList = new PersonBuilder(lastPerson);
+        Person editedPerson = personInList.withNickname(VALID_NICKNAME_BOB).build();
+
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withNickname(VALID_NICKNAME_BOB).build();
+        EditCommand editCommand = new EditCommand(indexLastPerson, descriptor);
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(lastPerson, editedPerson);
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_editNotesUnfilteredList_success() {
+        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
+        Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
+
+        PersonBuilder personInList = new PersonBuilder(lastPerson);
+        Person editedPerson = personInList.withNotes(VALID_NOTES_BOB).build();
+
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withNotes(VALID_NOTES_BOB).build();
         EditCommand editCommand = new EditCommand(indexLastPerson, descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));

--- a/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
@@ -60,13 +60,15 @@ public class EditPersonDescriptorTest {
     @Test
     public void toStringMethod() {
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
-        String expected = EditPersonDescriptor.class.getCanonicalName() + "{name="
-                + editPersonDescriptor.getName().orElse(null) + ", phone="
-                + editPersonDescriptor.getPhone().orElse(null) + ", email="
-                + editPersonDescriptor.getEmail().orElse(null) + ", address="
-                + editPersonDescriptor.getAddress().orElse(null) + ", birthday="
-                + editPersonDescriptor.getBirthday().orElse(null) + ", tags="
-                + editPersonDescriptor.getTags().orElse(null) + "}";
+        String expected = EditPersonDescriptor.class.getCanonicalName()
+                + "{name=" + editPersonDescriptor.getName().orElse(null)
+                + ", phone=" + editPersonDescriptor.getPhone().orElse(null)
+                + ", email=" + editPersonDescriptor.getEmail().orElse(null)
+                + ", address=" + editPersonDescriptor.getAddress().orElse(null)
+                + ", birthday=" + editPersonDescriptor.getBirthday().orElse(null)
+                + ", nickname=" + editPersonDescriptor.getNickname().orElse(null)
+                + ", notes=" + editPersonDescriptor.getNotes().orElse(null)
+                + ", tags=" + editPersonDescriptor.getTags().orElse(null) + "}";
         assertEquals(expected, editPersonDescriptor.toString());
     }
 }

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -8,6 +8,8 @@ import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_NICKNAME_LENGTH_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_NOTES_LENGTH_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
@@ -41,6 +43,8 @@ import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.Nickname;
+import seedu.address.model.person.Notes;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
@@ -101,6 +105,12 @@ public class EditCommandParserTest {
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_ADDRESS_AMY + VALID_PHONE_AMY,
                 Name.MESSAGE_CONSTRAINTS);
+
+        // Invalid nickname - too long
+        assertParseFailure(parser, "1" + INVALID_NICKNAME_LENGTH_DESC, Nickname.MESSAGE_CONSTRAINTS_LENGTH);
+
+        // Invalid notes - too long
+        assertParseFailure(parser, "1" + INVALID_NOTES_LENGTH_DESC, Notes.MESSAGE_CONSTRAINTS_LENGTH);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -94,7 +94,8 @@ public class PersonTest {
     public void toStringMethod() {
         String expected = Person.class.getCanonicalName() + "{name=" + ALICE.getName() + ", phone=" + ALICE.getPhone()
                 + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress() + ", birthday="
-                + ALICE.getBirthday() + ", tags=" + ALICE.getTags() + "}";
+                + ALICE.getBirthday() + ", nickname=" + ALICE.getNickname() + ", notes=" + ALICE.getNotes()
+                + ", tags=" + ALICE.getTags() + "}";
         assertEquals(expected, ALICE.toString());
     }
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -135,7 +135,7 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
                         VALID_BIRTHDAY, INVALID_NICKNAME, VALID_NOTES, VALID_TAGS);
-        String expectedMessage = Nickname.MESSAGE_CONSTRAINTS;
+        String expectedMessage = Nickname.MESSAGE_CONSTRAINTS_LENGTH;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
@@ -144,7 +144,7 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
                         VALID_BIRTHDAY, VALID_NICKNAME, INVALID_NOTES, VALID_TAGS);
-        String expectedMessage = Notes.MESSAGE_CONSTRAINTS;
+        String expectedMessage = Notes.MESSAGE_CONSTRAINTS_LENGTH;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -16,6 +16,8 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.Birthday;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.Nickname;
+import seedu.address.model.person.Notes;
 import seedu.address.model.person.Phone;
 
 public class JsonAdaptedPersonTest {
@@ -24,13 +26,24 @@ public class JsonAdaptedPersonTest {
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_BIRTHDAY = "31-02-2000";
+    private static final String INVALID_NICKNAME =
+            "This is a very long nickname that exceeds 30 characters";
+    private static final String INVALID_NOTES =
+            "This note is intentionally exceeding the maximum allowed length of 100 characters with "
+                    + "unnecessary and redundant information...";
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final String VALID_PHONE = BENSON.getPhone().toString();
     private static final String VALID_EMAIL = BENSON.getEmail().toString();
     private static final String VALID_ADDRESS = BENSON.getAddress().toString();
-    private static final String VALID_BIRTHDAY = BENSON.getBirthday().toString();
+    private static final String VALID_BIRTHDAY = BENSON.getBirthday()
+            .map(Birthday::toString)
+            .orElse("01-01-1990");
+    private static final String VALID_NICKNAME = BENSON.getNickname().map(Nickname::toString)
+            .orElse("");
+    private static final String VALID_NOTES = BENSON.getNotes().map(Notes::toString)
+            .orElse("");
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
@@ -45,7 +58,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        VALID_BIRTHDAY, VALID_TAGS);
+                        VALID_BIRTHDAY, VALID_NICKNAME, VALID_NOTES, VALID_TAGS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -53,7 +66,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_BIRTHDAY, VALID_TAGS);
+                VALID_BIRTHDAY, VALID_NICKNAME, VALID_NOTES, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -62,7 +75,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        VALID_BIRTHDAY, VALID_TAGS);
+                        VALID_BIRTHDAY, VALID_NICKNAME, VALID_NOTES, VALID_TAGS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -70,7 +83,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS,
-                VALID_BIRTHDAY, VALID_TAGS);
+                VALID_BIRTHDAY, VALID_NICKNAME, VALID_NOTES, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -79,7 +92,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS,
-                        VALID_BIRTHDAY, VALID_TAGS);
+                        VALID_BIRTHDAY, VALID_NICKNAME, VALID_NOTES, VALID_TAGS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -87,7 +100,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullEmail_noAssertionErrorThrown() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS,
-                VALID_BIRTHDAY, VALID_TAGS);
+                VALID_BIRTHDAY, VALID_NICKNAME, VALID_NOTES, VALID_TAGS);
         return;
     }
 
@@ -95,7 +108,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS,
-                        VALID_BIRTHDAY, VALID_TAGS);
+                        VALID_BIRTHDAY, VALID_NICKNAME, VALID_NOTES, VALID_TAGS);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -103,7 +116,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null,
-                VALID_BIRTHDAY, VALID_TAGS);
+                VALID_BIRTHDAY, VALID_NICKNAME, VALID_NOTES, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -112,15 +125,33 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidBirthday_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        INVALID_BIRTHDAY, VALID_TAGS);
+                        INVALID_BIRTHDAY, VALID_NICKNAME, VALID_NOTES, VALID_TAGS);
         String expectedMessage = Birthday.MESSAGE_BIRTHDAY_CONSTRAINTS_INVALID;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidNickname_throwsIllegalValueException() {
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                        VALID_BIRTHDAY, INVALID_NICKNAME, VALID_NOTES, VALID_TAGS);
+        String expectedMessage = Nickname.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidNotes_throwsIllegalValueException() {
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                        VALID_BIRTHDAY, VALID_NICKNAME, INVALID_NOTES, VALID_TAGS);
+        String expectedMessage = Notes.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullBirthday_noExceptionThrown() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                null, VALID_TAGS);
+                null, VALID_NICKNAME, VALID_NOTES, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Birthday.class.getSimpleName());
     }
 
@@ -129,7 +160,8 @@ public class JsonAdaptedPersonTest {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_BIRTHDAY, invalidTags);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                        VALID_BIRTHDAY, VALID_NICKNAME, VALID_NOTES, invalidTags);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -1,5 +1,6 @@
 package seedu.address.testutil;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -8,6 +9,8 @@ import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.Nickname;
+import seedu.address.model.person.Notes;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
@@ -70,6 +73,23 @@ public class EditPersonDescriptorBuilder {
         descriptor.setAddress(new Address(address));
         return this;
     }
+
+    /**
+     * Sets the {@code Nickname} of the {@code EditPersonDescriptor} that we are building.
+     */
+    public EditPersonDescriptorBuilder withNickname(String nickname) {
+        descriptor.setNickname(Optional.of(new Nickname(nickname)));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Notes} of the {@code EditPersonDescriptor} that we are building.
+     */
+    public EditPersonDescriptorBuilder withNotes(String notes) {
+        descriptor.setNotes(Optional.of(new Notes(notes)));
+        return this;
+    }
+
 
     /**
      * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code EditPersonDescriptor}

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -8,6 +8,8 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.Birthday;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.Nickname;
+import seedu.address.model.person.Notes;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
@@ -23,12 +25,16 @@ public class PersonBuilder {
     public static final String DEFAULT_EMAIL = "amy@gmail.com";
     public static final String DEFAULT_ADDRESS = "123, Jurong West Ave 6, #08-111";
     private static final String DEFAULT_BIRTHDAY = "01-01-1990";
+    private static final String DEFAULT_NICKNAME = "Nicholas";
+    private static final String DEFAULT_NOTES = "Allergic to peanuts";
 
     private Name name;
     private Phone phone;
     private Email email;
     private Address address;
     private Optional<Birthday> birthday;
+    private Optional<Nickname> nickname;
+    private Optional<Notes> notes;
     private Set<Tag> tags;
 
     /**
@@ -40,6 +46,8 @@ public class PersonBuilder {
         email = new Email(DEFAULT_EMAIL);
         address = new Address(DEFAULT_ADDRESS);
         birthday = Optional.empty();
+        nickname = Optional.empty();
+        notes = Optional.empty();
         tags = new HashSet<>();
     }
 
@@ -52,6 +60,8 @@ public class PersonBuilder {
         email = personToCopy.getEmail();
         address = personToCopy.getAddress();
         birthday = personToCopy.getBirthday();
+        nickname = personToCopy.getNickname();
+        notes = personToCopy.getNotes();
         tags = new HashSet<>(personToCopy.getTags());
     }
 
@@ -94,6 +104,22 @@ public class PersonBuilder {
     }
 
     /**
+     * Sets the {@code Nickname} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withNickname(String nickname) {
+        this.nickname = Optional.of(new Nickname(nickname));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Notes} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withNotes(String notes) {
+        this.notes = Optional.of(new Notes(notes));
+        return this;
+    }
+
+    /**
      * Sets the {@code Phone} of the {@code Person} that we are building.
      */
     public PersonBuilder withPhone(String phone) {
@@ -110,7 +136,7 @@ public class PersonBuilder {
     }
 
     public Person build() {
-        return new Person(name, phone, email, address, birthday, tags);
+        return new Person(name, phone, email, address, birthday, nickname, notes, tags);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -30,7 +30,8 @@ public class TypicalPersons {
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")
             .withEmail("johnd@example.com").withPhone("98765432")
-            .withTags("owesMoney", "friends").build();
+            .withBirthday("01-01-1990").withNickname("BENNY")
+            .withNotes("Allergic to peanuts").withTags("owesMoney", "friends").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withAddress("wall street").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")


### PR DESCRIPTION
This PR implements adding of notes and nicknames to family members.

fixes #50 

Currently, there are only length constraints for nickname and notes. 30 characters limit for nickname and 100 characters limit for notes.

**Check that these commands work as expected:**

1. add n/James Koh p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 t/friend t/colleague nn/Nicholas no/Allergic to peanuts
2. edit 5 no/Allergic to peanuts
3. edit 5 nn/Nicholas 