### PR TITLE
Update Messages class with new Person fields

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -18,7 +18,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
-                "Multiple values specified for the following single-valued field(s): ";
+            "Multiple values specified for the following single-valued field(s): ";
 
     /**
      * Returns an error message indicating the duplicate prefixes.
@@ -45,29 +45,10 @@ public class Messages {
                 .append("; Address: ")
                 .append(person.getAddress());
 
-        String birthdayValue = person.getBirthdayValue();
-        if (!birthdayValue.isEmpty()) {
-            builder.append("; Birthday: ")
-                    .append(birthdayValue);
-        }
-
-        String relationshipValue = person.getRelationshipValue();
-        if (!relationshipValue.isEmpty()) {
-            builder.append("; Relationship: ")
-                    .append(relationshipValue);
-        }
-
-        String nicknameValue = person.getNicknameValue();
-        if (!nicknameValue.isEmpty()) {
-            builder.append("; Nickname: ")
-                    .append(nicknameValue);
-        }
-
-        String notesValue = person.getNotesValue();
-        if (!notesValue.isEmpty()) {
-            builder.append("; Notes: ")
-                    .append(notesValue);
-        }
+        appendIfNotEmpty(builder, "Birthday", person.getBirthdayValue());
+        appendIfNotEmpty(builder, "Relationship", person.getRelationshipValue());
+        appendIfNotEmpty(builder, "Nickname", person.getNicknameValue());
+        appendIfNotEmpty(builder, "Notes", person.getNotesValue());
 
         Set<Tag> tags = person.getTags();
         if (!tags.isEmpty()) {
@@ -76,5 +57,14 @@ public class Messages {
         }
 
         return builder.toString();
+    }
+
+    private static void appendIfNotEmpty(StringBuilder builder, String fieldName, String value) {
+        if (!value.isEmpty()) {
+            builder.append("; ")
+                    .append(fieldName)
+                    .append(": ")
+                    .append(value);
+        }
     }
 }

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -6,6 +6,7 @@ import java.util.stream.Stream;
 
 import seedu.address.logic.parser.Prefix;
 import seedu.address.model.person.Person;
+import seedu.address.model.tag.Tag;
 
 /**
  * Container for user visible messages.
@@ -42,10 +43,38 @@ public class Messages {
                 .append("; Email: ")
                 .append(person.getEmail())
                 .append("; Address: ")
-                .append(person.getAddress())
-                .append("; Tags: ");
-        person.getTags().forEach(builder::append);
+                .append(person.getAddress());
+
+        String birthdayValue = person.getBirthdayValue();
+        if (!birthdayValue.isEmpty()) {
+            builder.append("; Birthday: ")
+                    .append(birthdayValue);
+        }
+
+        String relationshipValue = person.getRelationshipValue();
+        if (!relationshipValue.isEmpty()) {
+            builder.append("; Relationship: ")
+                    .append(relationshipValue);
+        }
+
+        String nicknameValue = person.getNicknameValue();
+        if (!nicknameValue.isEmpty()) {
+            builder.append("; Nickname: ")
+                    .append(nicknameValue);
+        }
+
+        String notesValue = person.getNotesValue();
+        if (!notesValue.isEmpty()) {
+            builder.append("; Notes: ")
+                    .append(notesValue);
+        }
+
+        Set<Tag> tags = person.getTags();
+        if (!tags.isEmpty()) {
+            builder.append("; Tags: ");
+            tags.forEach(builder::append);
+        }
+
         return builder.toString();
     }
-
 }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -67,15 +67,26 @@ public class Person {
     public Optional<Birthday> getBirthday() {
         return birthday;
     }
+    public String getBirthdayValue() {
+        return birthday.map(Object::toString).orElse("");
+    }
     public Optional<Relationship> getRelationship() {
         return relationship;
     }
-
+    public String getRelationshipValue() {
+        return relationship.map(Object::toString).orElse("");
+    }
     public Optional<Nickname> getNickname() {
         return nickname;
     }
+    public String getNicknameValue() {
+        return nickname.map(Object::toString).orElse("");
+    }
     public Optional<Notes> getNotes() {
         return notes;
+    }
+    public String getNotesValue() {
+        return notes.map(Object::toString).orElse("");
     }
 
     /**


### PR DESCRIPTION
fixes #57.

This PR fixes the issue where the console message does not reflect correctly when handling the new fields.

1. birthday
2. relationship
3. nickname
4. notes

For testing, check that the console message works with the new fields added recently:

```
add n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 r/Brother b/01-01-1990 nn/Jamie no/Allergic to peanuts t/friend t/colleague
```
<img width="1165" alt="Screenshot 2025-03-16 at 12 05 28 AM" src="https://github.com/user-attachments/assets/67bde1fc-4618-4efc-970a-628cacaca2ab" />



Note: Not sure if this violates SLAP
