### PR TITLE
Fix bug for Edit Relationship

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -185,7 +185,8 @@ public class EditCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, phone, email, address, birthday, nickname, notes, tags);
+            return CollectionUtil.isAnyNonNull(name, phone, email, address, birthday, relationship,
+                    nickname, notes, tags);
         }
 
         public void setName(Name name) {
@@ -211,13 +212,8 @@ public class EditCommand extends Command {
         public Optional<Email> getEmail() {
             return Optional.ofNullable(email);
         }
-
         public void setAddress(Address address) {
             this.address = address;
-        }
-
-        public void setNickname(Optional<Nickname> nickname) {
-            this.nickname = nickname;
         }
         public Optional<Address> getAddress() {
             return Optional.ofNullable(address);
@@ -233,6 +229,9 @@ public class EditCommand extends Command {
         }
         public Optional<Relationship> getRelationship() {
             return Optional.ofNullable(relationship).flatMap(b -> b);
+        }
+        public void setNickname(Optional<Nickname> nickname) {
+            this.nickname = nickname;
         }
         public Optional<Nickname> getNickname() {
             return Optional.ofNullable(nickname).flatMap(b -> b);

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -9,6 +9,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NICKNAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTES;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_RELATIONSHIP;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Collection;
@@ -36,7 +37,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
-                        PREFIX_BIRTHDAY, PREFIX_NICKNAME, PREFIX_NOTES, PREFIX_TAG);
+                        PREFIX_BIRTHDAY, PREFIX_RELATIONSHIP, PREFIX_NICKNAME, PREFIX_NOTES, PREFIX_TAG);
 
         Index index;
 
@@ -65,6 +66,9 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
         if (argMultimap.getValue(PREFIX_BIRTHDAY).isPresent()) {
             editPersonDescriptor.setBirthday(ParserUtil.parseBirthday(argMultimap.getValue(PREFIX_BIRTHDAY)));
+        }
+        if (argMultimap.getValue(PREFIX_RELATIONSHIP).isPresent()) {
+            editPersonDescriptor.setRelationship(ParserUtil.parseRelationship(argMultimap.getValue(PREFIX_RELATIONSHIP)));
         }
         if (argMultimap.getValue(PREFIX_NICKNAME).isPresent()) {
             editPersonDescriptor.setNickname(ParserUtil.parseNickname(argMultimap.getValue(PREFIX_NICKNAME)));

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -48,7 +48,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
-                PREFIX_BIRTHDAY, PREFIX_NICKNAME, PREFIX_NOTES);
+                PREFIX_RELATIONSHIP, PREFIX_BIRTHDAY, PREFIX_NICKNAME, PREFIX_NOTES);
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
 
@@ -68,7 +68,8 @@ public class EditCommandParser implements Parser<EditCommand> {
             editPersonDescriptor.setBirthday(ParserUtil.parseBirthday(argMultimap.getValue(PREFIX_BIRTHDAY)));
         }
         if (argMultimap.getValue(PREFIX_RELATIONSHIP).isPresent()) {
-            editPersonDescriptor.setRelationship(ParserUtil.parseRelationship(argMultimap.getValue(PREFIX_RELATIONSHIP)));
+            editPersonDescriptor.setRelationship(ParserUtil
+                    .parseRelationship(argMultimap.getValue(PREFIX_RELATIONSHIP)));
         }
         if (argMultimap.getValue(PREFIX_NICKNAME).isPresent()) {
             editPersonDescriptor.setNickname(ParserUtil.parseNickname(argMultimap.getValue(PREFIX_NICKNAME)));

--- a/src/main/java/seedu/address/model/person/Relationship.java
+++ b/src/main/java/seedu/address/model/person/Relationship.java
@@ -13,7 +13,6 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Relationship {
 
     public static final String MESSAGE_CONSTRAINTS = "Relationships should have alphanumeric characters.";
-
     public static final String VALIDATION_REGEX = "\\p{Alnum}+";
 
     public final String relationship;


### PR DESCRIPTION
As mentioned in issue #62:

Edit command works with relationship when paired with another field, e.g:
```
edit 2 n/Hello r/Mother 
```
but fails when trying to edit relationship field by itself, e.g:

```
edit 2 r/Mother
```

This PR fixes #62 🔥 