### PR TITLE
Fix duplicate index handling and add test cases

### DIFF
--- a/src/main/java/seedu/address/commons/core/index/Index.java
+++ b/src/main/java/seedu/address/commons/core/index/Index.java
@@ -63,6 +63,11 @@ public class Index {
     }
 
     @Override
+    public int hashCode() {
+        return Integer.hashCode(zeroBasedIndex);
+    }
+
+    @Override
     public String toString() {
         return new ToStringBuilder(this).add("zeroBasedIndex", zeroBasedIndex).toString();
     }

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -18,6 +18,7 @@ public class Messages {
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
+    public static final String MESSAGE_DUPLICATE_INDEX = "Duplicate indices are not allowed for this command. %s";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -52,10 +52,11 @@ public class DeleteCommand extends Command {
             model.deletePerson(personToDelete);
         }
 
-        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS,
-                personsToDelete.stream()
-                        .map(Messages::format)
-                        .collect(Collectors.joining(","))));
+        String deletedPersonsSummary = personsToDelete.stream()
+                .map(Messages::format)
+                .collect(Collectors.joining(","));
+
+        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, deletedPersonsSummary));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -1,12 +1,15 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_DUPLICATE_INDEX;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.parser.exceptions.DuplicateIndexParseException;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -22,16 +25,27 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
     public DeleteCommand parse(String args) throws ParseException {
         try {
             List<Index> targetIndices = new ArrayList<>();
+            HashSet<Index> seenIndices = new HashSet<>();
             String[] indicesStr = args.trim().split("\\s+");
 
             for (String indexStr : indicesStr) {
-                targetIndices.add(ParserUtil.parseIndex(indexStr));
+                Index index = ParserUtil.parseIndex(indexStr);
+                if (!seenIndices.add(index)) {
+                    throw new DuplicateIndexParseException(
+                            String.format(MESSAGE_DUPLICATE_INDEX, "Entered: delete " + args)
+                    );
+                }
+                targetIndices.add(index);
             }
-
             return new DeleteCommand(targetIndices);
+
+        } catch (DuplicateIndexParseException de) {
+            throw de;
+
         } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe
+            );
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/exceptions/DuplicateIndexParseException.java
+++ b/src/main/java/seedu/address/logic/parser/exceptions/DuplicateIndexParseException.java
@@ -1,0 +1,14 @@
+package seedu.address.logic.parser.exceptions;
+
+/**
+ * Represents a Duplicate Index parse error encountered by a parser.
+ */
+public class DuplicateIndexParseException extends ParseException {
+    public DuplicateIndexParseException(String message) {
+        super(message);
+    }
+
+    public DuplicateIndexParseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -95,6 +95,14 @@ public class DeleteCommandTest {
     }
 
     @Test
+    public void execute_emptyList_throwsCommandException() {
+        Model emptyModel = new ModelManager();
+        DeleteCommand deleteCommand = new DeleteCommand(List.of(INDEX_FIRST_PERSON));
+
+        assertCommandFailure(deleteCommand, emptyModel, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
     public void equals() {
         DeleteCommand deleteFirstCommand = new DeleteCommand(List.of(INDEX_FIRST_PERSON));
         DeleteCommand deleteSecondCommand = new DeleteCommand(List.of(INDEX_SECOND_PERSON));

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -1,10 +1,10 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_DUPLICATE_INDEX;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalIndexes.*;
 
 import java.util.List;
 
@@ -26,6 +26,12 @@ public class DeleteCommandParserTest {
     private DeleteCommandParser parser = new DeleteCommandParser();
 
     @Test
+    public void parse_emptyArgs_throwsParseException() {
+        String userInput = "";
+        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
     public void parse_validArgs_returnsDeleteCommand() {
         assertParseSuccess(parser, "1", new DeleteCommand(List.of(INDEX_FIRST_PERSON)));
     }
@@ -39,8 +45,38 @@ public class DeleteCommandParserTest {
         assertParseSuccess(parser, "1                   2",
                 new DeleteCommand(List.of(INDEX_FIRST_PERSON, INDEX_SECOND_PERSON)));
     }
+
+    @Test
+    public void parse_leadingAndTrailingWhitespace_returnsDeleteCommand() {
+        assertParseSuccess(parser, "   1 2 3   ",
+                new DeleteCommand(List.of(INDEX_FIRST_PERSON, INDEX_SECOND_PERSON, INDEX_THIRD_PERSON)));
+    }
+
     @Test
     public void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
+
+    @Test
+    public void parse_negativeIndex_throwsParseException() {
+        String userInput = "-1 2";
+        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_duplicateIndices_throwsDuplicateIndexParseException() {
+        String userInput = "1 1";
+        String expectedMessage = String.format(MESSAGE_DUPLICATE_INDEX, "Entered: delete " + userInput);
+
+        assertParseFailure(parser, userInput, expectedMessage);
+    }
+
+    @Test
+    public void parse_duplicateNonConsecutiveIndices_throwsDuplicateIndexParseException() {
+        String userInput = "1 2 1";
+        String expectedMessage = String.format(MESSAGE_DUPLICATE_INDEX, "Entered: delete " + userInput);
+
+        assertParseFailure(parser, userInput, expectedMessage);
+    }
+
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -30,7 +30,8 @@ public class DeleteCommandParserTest {
     @Test
     public void parse_emptyArgs_throwsParseException() {
         String userInput = "";
-        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, userInput,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 
     @Test
@@ -56,13 +57,15 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_negativeIndex_throwsParseException() {
         String userInput = "-1 2";
-        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, userInput,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -4,7 +4,9 @@ import static seedu.address.logic.Messages.MESSAGE_DUPLICATE_INDEX;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalIndexes.*;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
 
 import java.util.List;
 


### PR DESCRIPTION
Currently, DeleteCommandParser does not properly reject duplicate indices, leading to unexpected behavior when parsing user input.

This commit:
- Detects duplicate indices early and rejects them with an error.
- Adds test cases for empty input, duplicate indices, and negative indices.
- Adds test case for empty list delete.
- Fixes #70 , #72 

This improves parser robustness and prevents unintended command execution.