### PR TITLE
Typo in DG

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -475,8 +475,6 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 7. All commands should execute and display results within 2 seconds on a standard computer system.
 8. All family data should be stored locally.
 
-
-```
 ### Glossary
 
 * **Mainstream OS**: Windows, Linux, Unix, MacOS


### PR DESCRIPTION
Fix DG to display the below section clearly:
![image](https://github.com/user-attachments/assets/5c5b2fd7-07e6-4679-803b-5df8159ece67)

fixes #83 