### PR TITLE
Fix Validation fails when seeding sample data 

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -199,7 +199,7 @@ public class ParserUtil {
         }
         requireNonNull(relationship);
         String trimmedRelationship = relationship.get().trim();
-        if (!Tag.isValidTagName(trimmedRelationship)) {
+        if (!Relationship.isValidRelationship(trimmedRelationship)) {
             throw new ParseException(Relationship.MESSAGE_CONSTRAINTS);
         }
         return Optional.of(new Relationship(trimmedRelationship));

--- a/src/main/java/seedu/address/model/person/Relationship.java
+++ b/src/main/java/seedu/address/model/person/Relationship.java
@@ -13,7 +13,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Relationship {
 
     public static final String MESSAGE_CONSTRAINTS = "Relationships should have alphanumeric characters.";
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}\\s]+";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}\\s-]+";
     public final String relationship;
 
     /**

--- a/src/main/java/seedu/address/model/person/Relationship.java
+++ b/src/main/java/seedu/address/model/person/Relationship.java
@@ -13,8 +13,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Relationship {
 
     public static final String MESSAGE_CONSTRAINTS = "Relationships should have alphanumeric characters.";
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
-
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}\\s]+";
     public final String relationship;
 
     /**

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -79,7 +79,7 @@ public class LogicManagerTest {
 
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
-        String deleteCommand = "delete 9";
+        String deleteCommand = "delete 10";
         assertCommandException(deleteCommand, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 


### PR DESCRIPTION
As highlighted in #64, validation of Relationship fields for the sample data does not pass. This is particularly present for Relationships that utilise whitespace (e.g. Kor Kor - as highlighted by @Benjam11n ). This PR fixes #64.

With this pull request, the bug in the `VALIDATION_REGEX` of Relationship has been fixed. The key changes of this pull request are:
- Amendment of `VALIDATION_REGEX` of Relationship to allow for whitespace.
- Fix a bug in ParserUtil that was causing `parseRelationship` to use `Tag.VALIDATION_REGEX` instead of `Relationship.VALIDATION_REGEX`.

This commit now allows the `add` and `edit` command to amend relationships to contain whitespace characters as shown below. 

Running `edit 1 r/Best Friend Forever`:

![image](https://github.com/user-attachments/assets/b6031c7f-eeee-4458-8454-4c1a3125a72c)

For future improvements:
- We can look into ensuring that the length of a Relationship does not exceed more than a set number of characters (e.g. 72 characters max.). This could be good for ensuring conciseness as well as UI quality.