### PR TITLE
Fix UI: Placeholder for missing relationship, trim whitespace

### DIFF
--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -8,7 +8,6 @@ import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.address.model.person.Birthday;
-import seedu.address.model.person.Nickname;
 import seedu.address.model.person.Notes;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Relationship;
@@ -61,13 +60,35 @@ public class PersonCard extends UiPart<Region> {
         this.person = person;
         id.setText(displayedIndex + ". ");
         name.setText(person.getName().fullName);
+        if (person.getNickname().isPresent()) {
+            nickname.setText(" (" + person.getNickname().get() + ")");
+        } else {
+            nickname.setVisible(false);
+            nickname.setManaged(false);
+        }
         phone.setText(person.getPhone().value);
         address.setText(person.getAddress().value);
         email.setText(person.getEmail().value);
-        birthday.setText(person.getBirthday().map(Birthday::getBirthdayStringFormatted).orElse(""));
-        relationship.setText(person.getRelationship().map(Relationship::getRelationshipString).orElse(""));
-        nickname.setText(person.getNickname().map(Nickname::toString).orElse(""));
-        notes.setText(person.getNotes().map(Notes::toString).orElse(""));
+
+        String birthdayText = person.getBirthday().map(Birthday::getBirthdayStringFormatted).orElse("");
+        if (birthdayText.isEmpty()) {
+            birthday.setVisible(false);
+            birthday.setManaged(false);
+        } else {
+            birthday.setText(birthdayText);
+        }
+
+        relationship.setText(person.getRelationship()
+                .map(Relationship::getRelationshipString).orElse("No relationship specified"));
+
+        String notesText = person.getNotes().map(Notes::toString).orElse("");
+        if (notesText.isEmpty()) {
+            notes.setVisible(false);
+            notes.setManaged(false);
+        } else {
+            notes.setText(notesText);
+        }
+
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -120,6 +120,13 @@
     -fx-text-fill: white;
 }
 
+.cell_nickname_label {
+    -fx-font-family: "Arial";
+    -fx-font-style: italic;
+    -fx-font-size: 13px;
+    -fx-text-fill: white;
+}
+
 .cell_big_label {
     -fx-font-family: "Segoe UI Semibold";
     -fx-font-size: 16px;
@@ -133,7 +140,7 @@
 }
 
 .cell_relationship_label {
-    -fx-text-fill: white;
+    -fx-text-fill: black !important;
     -fx-background-color: #ffa500;
     -fx-padding: 1 3 1 3;
     -fx-border-radius: 2;

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -26,6 +26,7 @@
           </minWidth>
         </Label>
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+        <Label fx:id="nickname" styleClass="cell_nickname_label" text="\$nickname" />
       </HBox>
       <Label fx:id="relationship" styleClass="cell_relationship_label" text="\$relationship" />
       <FlowPane fx:id="tags" />
@@ -33,7 +34,6 @@
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
       <Label fx:id="birthday" styleClass="cell_small_label" text="\$birthday" />
-      <Label fx:id="nickname" styleClass="cell_small_label" text="\$nickname" />
       <Label fx:id="notes" styleClass="cell_small_label" text="\$notes" />
     </VBox>
   </GridPane>


### PR DESCRIPTION
Currently, when a relationship is missing, the UI displays an empty string box. Additionally, optional fields like birthday and notes create unnecessry whitespace when empty. Lastly, nicknames should also be displayed inline with the name for clarity.

Let's
- Update the UI to show a placeholder text ("No relationship specified") when no relationship is provided.
- We also hide label for empty optional fields to ensure a cleaner and more structured layout.
- Place the nickname inlign with the name.