### PR TITLE
Add RelationshipTest for Relationship testing

### DIFF
--- a/src/test/java/seedu/address/model/person/RelationshipTest.java
+++ b/src/test/java/seedu/address/model/person/RelationshipTest.java
@@ -1,0 +1,59 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class RelationshipTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Relationship(null));
+    }
+
+    @Test
+    public void constructor_invalidRelationship_throwsIllegalArgumentException() {
+        String invalidRelationship = "";
+        assertThrows(IllegalArgumentException.class, () -> new Relationship(invalidRelationship));
+    }
+
+    @Test
+    public void isValidRelationship() {
+        // null relationship
+        assertThrows(NullPointerException.class, () -> Relationship.isValidRelationship(null));
+
+        // invalid relationship
+        assertFalse(Relationship.isValidRelationship("")); // empty string
+        assertFalse(Relationship.isValidRelationship("^")); // only non-alphanumeric characters
+        assertFalse(Relationship.isValidRelationship("mother*")); // contains non-alphanumeric characters
+
+        // valid relationship
+        assertTrue(Relationship.isValidRelationship("mother")); // alphabets only
+        assertTrue(Relationship.isValidRelationship("12345")); // numbers only
+        assertTrue(Relationship.isValidRelationship("father 2nd")); // alphanumeric characters
+        assertTrue(Relationship.isValidRelationship("Grand Father")); // with capital letters
+        assertTrue(Relationship.isValidRelationship("Great Grand Mother")); // long relationships
+    }
+
+    @Test
+    public void equals() {
+        Relationship relationship = new Relationship("Valid Relationship");
+
+        // same values -> returns true
+        assertTrue(relationship.equals(new Relationship("Valid Relationship")));
+
+        // same object -> returns true
+        assertTrue(relationship.equals(relationship));
+
+        // null -> returns false
+        assertFalse(relationship.equals(null));
+
+        // different types -> returns false
+        assertFalse(relationship.equals(5.0f));
+
+        // different values -> returns false
+        assertFalse(relationship.equals(new Relationship("Other Valid Relationship")));
+    }
+}


### PR DESCRIPTION
Currently, the Relationship class lacks comprehensive unit tests to ensure its functionality and validation logic works as intended.

Without proper test coverage, we risk introducing bugs or regressions when modifying Relationship in the future. Comprehensive tests help maintain code quality and catch potential issues early.

Let's add a RelationshipTest class to test the Relationship class. In particular, we test for:
- Constructor behaviour with null and invalid inputs
- Validation of various relationship strings to ensure that `VALIDATION_REGEX` works as intended
- Equality comparisons using the `equals` method

The test class follows the conventions previously laid out by other Test classes and covers various basic scenarios to ensure robust validation of Relationship. It includes various positive and negative test cases, helping to verify the correctness of the implementation of the Relationship class.

For future commits: Let's continue to add more edge cases in order to truly gauge the functionality of Relationship! (e.g. non ASCII characters, symbol only checks etc.)

Fixes #93 