### PR TITLE
Add sorting by upcoming birthday with fallback order

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -3,22 +3,78 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
+import java.time.LocalDate;
+import java.time.MonthDay;
+import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
+
 import seedu.address.model.Model;
+import seedu.address.model.person.Person;
 
 /**
  * Lists all persons in the address book to the user.
  */
 public class ListCommand extends Command {
-
+    /**
+     * Represents the sort order of the list command.
+     */
+    public enum SortOrder {
+        ASCENDING,
+        DESCENDING,
+        NONE
+    }
     public static final String COMMAND_WORD = "list";
-
     public static final String MESSAGE_SUCCESS = "Listed all persons";
+    public static final String MESSAGE_ASC_SUCCESS = "Listed all persons by upcoming birthdays (soonest first)";
+    public static final String MESSAGE_DESC_SUCCESS = "Listed all persons by upcoming birthdays (latest first)";
+    private final SortOrder sortOrder;
 
+    public ListCommand() {
+        this.sortOrder = SortOrder.NONE;
+    }
+    public ListCommand(SortOrder sortOrder) {
+        this.sortOrder = sortOrder;
+    }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(MESSAGE_SUCCESS);
+        if (this.sortOrder == SortOrder.NONE) {
+            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+            model.sortFilteredPersonList(null);
+            return new CommandResult(MESSAGE_SUCCESS);
+        } else {
+            String successMessage = this.sortOrder == SortOrder.ASCENDING ? MESSAGE_ASC_SUCCESS : MESSAGE_DESC_SUCCESS;
+            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+            LocalDate today = LocalDate.now();
+
+            Comparator<Person> birthdayComparator = Comparator.comparing(
+                    person -> person.getBirthday()
+                            .map(b -> {
+                                LocalDate birthDate = b.getLocalDate();
+                                if (birthDate == null) {
+                                    return Long.MAX_VALUE;
+                                }
+
+                                MonthDay birthdayMonthDay = MonthDay.from(birthDate);
+                                MonthDay currentMonthDay = MonthDay.from(today);
+                                LocalDate nextBirthday = birthdayMonthDay.atYear(today.getYear());
+                                if (birthdayMonthDay.isBefore(currentMonthDay)) {
+                                    nextBirthday = nextBirthday.plusYears(1);
+                                }
+
+                                return ChronoUnit.DAYS.between(today, nextBirthday);
+                            })
+                            .orElse(Long.MAX_VALUE),
+                    Comparator.naturalOrder()
+            );
+
+            if (sortOrder == SortOrder.DESCENDING) {
+                birthdayComparator = birthdayComparator.reversed();
+            }
+            model.sortFilteredPersonList(birthdayComparator);
+
+            return new CommandResult(successMessage);
+        }
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -29,9 +29,17 @@ public class ListCommand extends Command {
     public static final String MESSAGE_DESC_SUCCESS = "Listed all persons by upcoming birthdays (latest first)";
     private final SortOrder sortOrder;
 
+    /**
+     * Creates a ListCommand with the default sort order.
+     */
     public ListCommand() {
         this.sortOrder = SortOrder.NONE;
     }
+    /**
+     * Creates a ListCommand with the specified sort order.
+     * Extended Constructor for testing purposes
+     * @param sortOrder
+     */
     public ListCommand(SortOrder sortOrder) {
         this.sortOrder = sortOrder;
     }
@@ -39,45 +47,64 @@ public class ListCommand extends Command {
         return this.sortOrder;
     }
 
+    /**
+     * Returns a comparator that compares persons by their upcoming birthday with todays date.
+     * @param today
+     * @param descending
+     * @return
+     */
+    public static Comparator<Person> getBirthdayComparator(LocalDate today, boolean descending) {
+        Comparator<Person> comparator = Comparator.comparing(
+                person -> person.getBirthday()
+                        .map(b -> {
+                            LocalDate birthDate = b.getLocalDate();
+                            if (birthDate == null) {
+                                return Long.MAX_VALUE;
+                            }
+
+                            MonthDay birthdayMonthDay = MonthDay.from(birthDate);
+                            MonthDay currentMonthDay = MonthDay.from(today);
+                            LocalDate nextBirthday = birthdayMonthDay.atYear(today.getYear());
+                            if (birthdayMonthDay.isBefore(currentMonthDay)) {
+                                nextBirthday = nextBirthday.plusYears(1);
+                            }
+
+                            return ChronoUnit.DAYS.between(today, nextBirthday);
+                        })
+                        .orElse(Long.MAX_VALUE),
+                Comparator.naturalOrder()
+        );
+
+        return descending ? comparator.reversed() : comparator;
+    }
+
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+
         if (this.sortOrder == SortOrder.NONE) {
-            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
             model.sortFilteredPersonList(null);
             return new CommandResult(MESSAGE_SUCCESS);
-        } else {
-            String successMessage = this.sortOrder == SortOrder.ASCENDING ? MESSAGE_ASC_SUCCESS : MESSAGE_DESC_SUCCESS;
-            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-            LocalDate today = LocalDate.now();
-
-            Comparator<Person> birthdayComparator = Comparator.comparing(
-                    person -> person.getBirthday()
-                            .map(b -> {
-                                LocalDate birthDate = b.getLocalDate();
-                                if (birthDate == null) {
-                                    return Long.MAX_VALUE;
-                                }
-
-                                MonthDay birthdayMonthDay = MonthDay.from(birthDate);
-                                MonthDay currentMonthDay = MonthDay.from(today);
-                                LocalDate nextBirthday = birthdayMonthDay.atYear(today.getYear());
-                                if (birthdayMonthDay.isBefore(currentMonthDay)) {
-                                    nextBirthday = nextBirthday.plusYears(1);
-                                }
-
-                                return ChronoUnit.DAYS.between(today, nextBirthday);
-                            })
-                            .orElse(Long.MAX_VALUE),
-                    Comparator.naturalOrder()
-            );
-
-            if (sortOrder == SortOrder.DESCENDING) {
-                birthdayComparator = birthdayComparator.reversed();
-            }
-            model.sortFilteredPersonList(birthdayComparator);
-
-            return new CommandResult(successMessage);
         }
+
+        boolean isDescending = this.sortOrder == SortOrder.DESCENDING;
+        Comparator<Person> birthdayComparator = getBirthdayComparator(LocalDate.now(), isDescending);
+        model.sortFilteredPersonList(birthdayComparator);
+
+        String successMessage = isDescending ? MESSAGE_DESC_SUCCESS : MESSAGE_ASC_SUCCESS;
+        return new CommandResult(successMessage);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this
+                || (other instanceof ListCommand
+                && this.sortOrder == ((ListCommand) other).sortOrder);
+    }
+
+    @Override
+    public int hashCode() {
+        return sortOrder.hashCode();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -35,6 +35,9 @@ public class ListCommand extends Command {
     public ListCommand(SortOrder sortOrder) {
         this.sortOrder = sortOrder;
     }
+    public SortOrder getSortOrder() {
+        return this.sortOrder;
+    }
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -70,7 +70,7 @@ public class AddressBookParser {
             return new FindCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
-            return new ListCommand();
+            return new ListCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -15,4 +15,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_RELATIONSHIP = new Prefix("r/");
     public static final Prefix PREFIX_NICKNAME = new Prefix("nn/");
     public static final Prefix PREFIX_NOTES = new Prefix("no/");
+    public static final Prefix PREFIX_SORT = new Prefix("s/");
 }

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -1,0 +1,54 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT;
+
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ListCommand object
+ */
+public class ListCommandParser implements Parser<ListCommand> {
+    public static final String ASCENDING_ORDER = "asc";
+    public static final String DESCENDING_ORDER = "desc";
+    public static final String COMMAND_USAGE = "list : Lists all persons in the address book\n"
+            + "Parameters (optional): "
+            + PREFIX_SORT + "SORT_ORDER [asc / desc]\n"
+            + "Example: list " + PREFIX_SORT + "asc";
+    private static final Logger logger = LogsCenter.getLogger(AddressBookParser.class);
+    /**
+     * Parses the given {@code String} of arguments in the context of the ListCommand
+     * and returns a ListCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ListCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+
+        if (args == null || trimmedArgs.isEmpty()) {
+            return new ListCommand(ListCommand.SortOrder.NONE);
+        }
+        trimmedArgs = " " + trimmedArgs; // precede with space for tokenizer
+
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(trimmedArgs, PREFIX_SORT);
+        if (!argMultimap.getPreamble().isBlank()) {
+            throw new ParseException("Invalid command format.\n" + COMMAND_USAGE);
+        }
+        Optional<String> sort = argMultimap.getValue(PREFIX_SORT).map(String::toLowerCase).map(String::trim);
+
+        if (sort.isEmpty()) {
+            return new ListCommand(ListCommand.SortOrder.NONE);
+        }
+        switch (sort.get()) {
+        case ASCENDING_ORDER:
+            return new ListCommand(ListCommand.SortOrder.ASCENDING);
+        case DESCENDING_ORDER:
+            return new ListCommand(ListCommand.SortOrder.DESCENDING);
+        default:
+            throw new ParseException("Invalid sort order!\n" + COMMAND_USAGE);
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -94,4 +95,10 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    /**
+     * Sorts the filtered person list by the given {@code comparator}.
+     * @throws NullPointerException if {@code comparator} is null.
+     */
+    void sortFilteredPersonList(Comparator<Person> comparator);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -8,7 +8,6 @@ import java.util.Comparator;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
-import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import javafx.collections.transformation.SortedList;

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,11 +4,14 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
+import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
+import javafx.collections.transformation.SortedList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Person;
@@ -23,6 +26,7 @@ public class ModelManager implements Model {
     private final UserPrefs userPrefs;
     private final CommandHistory commandHistory;
     private final FilteredList<Person> filteredPersons;
+    private final SortedList<Person> sortedPersons;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -37,7 +41,8 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         this.commandHistory = new CommandHistory(commandHistory);
-        filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
+        this.filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
+        this.sortedPersons = new SortedList<>(filteredPersons);
     }
 
     public ModelManager() {
@@ -135,13 +140,23 @@ public class ModelManager implements Model {
      */
     @Override
     public ObservableList<Person> getFilteredPersonList() {
-        return filteredPersons;
+        return sortedPersons;
     }
 
     @Override
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
+    }
+
+    /**
+     * Sorts the filtered person list by the given {@code comparator}.
+     * @param comparator
+     */
+    @Override
+    public void sortFilteredPersonList(Comparator<Person> comparator) {
+        // Allow null, to have original ordering (by order of addition)
+        sortedPersons.setComparator(comparator);
     }
 
     @Override

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -11,7 +11,7 @@
     "phone" : "98765432",
     "email" : "johnd@example.com",
     "address" : "311, Clementi Ave 2, #02-25",
-    "birthday" : "01-01-1990",
+    "birthday" : "02-02-1991",
     "relationship" : "Neighbour",
     "nickname" : "BENNY",
     "notes" : "Allergic to peanuts",
@@ -21,18 +21,21 @@
     "phone" : "95352563",
     "email" : "heinz@example.com",
     "address" : "wall street",
+    "birthday" : "03-03-1992",
     "tags" : [ ]
   }, {
     "name" : "Daniel Meier",
     "phone" : "87652533",
     "email" : "cornelia@example.com",
     "address" : "10th street",
+    "birthday" : "04-04-1993",
     "tags" : [ "friends" ]
   }, {
     "name" : "Elle Meyer",
     "phone" : "9482224",
     "email" : "werner@example.com",
     "address" : "michegan ave",
+    "birthday" : "05-05-1994",
     "tags" : [ ]
   }, {
     "name" : "Fiona Kunz",
@@ -45,12 +48,14 @@
     "phone" : "9482442",
     "email" : "anna@example.com",
     "address" : "4th street",
+    "birthday" : "07-07-1996",
     "tags" : [ ]
   }, {
     "name" : "John Guul",
     "phone" : "9482555",
     "email" : "john@example.com",
     "address" : "kazakhstan",
+    "birthday" : "08-08-1997",
     "tags" : [ ]
   }, {
     "name" : "Jon Buul",

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -10,6 +10,7 @@ import static seedu.address.testutil.TypicalPersons.ALICE;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -166,6 +167,11 @@ public class AddCommandTest {
 
         @Override
         public void updateFilteredPersonList(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void sortFilteredPersonList(Comparator<Person> comparator) {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -12,6 +12,12 @@ import seedu.address.model.CommandHistory;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.PersonBuilder;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
@@ -37,4 +43,99 @@ public class ListCommandTest {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
         assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
     }
+
+    @Test
+    public void execute_sortNone_success() {
+        ListCommand command = new ListCommand(); // default is NONE
+        expectedModel.sortFilteredPersonList(null);
+
+        assertCommandSuccess(command, model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_sortAsc_success() {
+        ListCommand command = new ListCommand(ListCommand.SortOrder.ASCENDING);
+
+        // Use same date for both command and expectedModel to ensure consistency
+        LocalDate fixedToday = LocalDate.now();
+        Comparator<Person> comparator = ListCommand.getBirthdayComparator(fixedToday, false);
+        expectedModel.sortFilteredPersonList(comparator);
+
+        assertCommandSuccess(command, model, ListCommand.MESSAGE_ASC_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_sortDesc_success() {
+        ListCommand command = new ListCommand(ListCommand.SortOrder.DESCENDING);
+
+        LocalDate fixedToday = LocalDate.now();
+        Comparator<Person> comparator = ListCommand.getBirthdayComparator(fixedToday, true);
+        expectedModel.sortFilteredPersonList(comparator);
+
+        assertCommandSuccess(command, model, ListCommand.MESSAGE_DESC_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_sortAsc_withMissingBirthdays_success() {
+        Person noBirthday = new PersonBuilder().withName("NoBday").build();
+        model.addPerson(noBirthday);
+        expectedModel.addPerson(noBirthday);
+
+        expectedModel.sortFilteredPersonList(
+                ListCommand.getBirthdayComparator(LocalDate.now(), false)
+        );
+
+        assertCommandSuccess(new ListCommand(ListCommand.SortOrder.ASCENDING),
+                model, ListCommand.MESSAGE_ASC_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_sortAsc_withBirthdayToday_success() {
+        Person todayBday = new PersonBuilder().withName("TodayBday")
+                .withBirthday(LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-yyyy")))
+                .build();
+
+        model.addPerson(todayBday);
+        expectedModel.addPerson(todayBday);
+
+        expectedModel.sortFilteredPersonList(
+                ListCommand.getBirthdayComparator(LocalDate.now(), false)
+        );
+
+        assertCommandSuccess(new ListCommand(ListCommand.SortOrder.ASCENDING),
+                model, ListCommand.MESSAGE_ASC_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_sortDesc_withMissingBirthdays_success() {
+        Person noBirthday = new PersonBuilder().withName("NoBday").build();
+        model.addPerson(noBirthday);
+        expectedModel.addPerson(noBirthday);
+
+        expectedModel.sortFilteredPersonList(
+                ListCommand.getBirthdayComparator(LocalDate.now(), true)
+        );
+
+        assertCommandSuccess(new ListCommand(ListCommand.SortOrder.DESCENDING),
+                model, ListCommand.MESSAGE_DESC_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_sortDesc_withBirthdayToday_success() {
+        Person todayBday = new PersonBuilder().withName("TodayBday")
+                .withBirthday(LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-yyyy")))
+                .build();
+
+        model.addPerson(todayBday);
+        expectedModel.addPerson(todayBday);
+
+        expectedModel.sortFilteredPersonList(
+                ListCommand.getBirthdayComparator(LocalDate.now(), true)
+        );
+
+        assertCommandSuccess(new ListCommand(ListCommand.SortOrder.DESCENDING),
+                model, ListCommand.MESSAGE_DESC_SUCCESS, expectedModel);
+    }
+
+
 }

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -5,6 +5,10 @@ import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -14,10 +18,6 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.PersonBuilder;
-
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.util.Comparator;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
@@ -76,7 +76,7 @@ public class ListCommandTest {
     }
 
     @Test
-    public void execute_sortAsc_withMissingBirthdays_success() {
+    public void execute_sortAscWithMissingBirthdays_success() {
         Person noBirthday = new PersonBuilder().withName("NoBday").build();
         model.addPerson(noBirthday);
         expectedModel.addPerson(noBirthday);
@@ -90,7 +90,7 @@ public class ListCommandTest {
     }
 
     @Test
-    public void execute_sortAsc_withBirthdayToday_success() {
+    public void execute_sortAscWithBirthdayToday_success() {
         Person todayBday = new PersonBuilder().withName("TodayBday")
                 .withBirthday(LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-yyyy")))
                 .build();
@@ -107,7 +107,7 @@ public class ListCommandTest {
     }
 
     @Test
-    public void execute_sortDesc_withMissingBirthdays_success() {
+    public void execute_sortDescWithMissingBirthdays_success() {
         Person noBirthday = new PersonBuilder().withName("NoBday").build();
         model.addPerson(noBirthday);
         expectedModel.addPerson(noBirthday);
@@ -121,7 +121,7 @@ public class ListCommandTest {
     }
 
     @Test
-    public void execute_sortDesc_withBirthdayToday_success() {
+    public void execute_sortDescWithBirthdayToday_success() {
         Person todayBday = new PersonBuilder().withName("TodayBday")
                 .withBirthday(LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-yyyy")))
                 .build();

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -84,8 +84,13 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_list() throws Exception {
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+        ListCommand listDefault = (ListCommand) parser.parseCommand("list");
+        ListCommand listAsc = (ListCommand) parser.parseCommand("list s/asc");
+        ListCommand listDesc = (ListCommand) parser.parseCommand("list s/desc");
+
+        assertEquals(ListCommand.SortOrder.NONE, listDefault.getSortOrder());
+        assertEquals(ListCommand.SortOrder.ASCENDING, listAsc.getSortOrder());
+        assertEquals(ListCommand.SortOrder.DESCENDING, listDesc.getSortOrder());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ListCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ListCommandParserTest.java
@@ -1,13 +1,14 @@
 package seedu.address.logic.parser;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT;
+import static seedu.address.testutil.Assert.assertThrows;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT;
 
 public class ListCommandParserTest {
     private ListCommandParser parser;

--- a/src/test/java/seedu/address/logic/parser/ListCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ListCommandParserTest.java
@@ -1,0 +1,59 @@
+package seedu.address.logic.parser;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT;
+
+public class ListCommandParserTest {
+    private ListCommandParser parser;
+
+    @BeforeEach
+    public void setUp() {
+        parser = new ListCommandParser();
+    }
+
+    @Test
+    public void parse_noArgs_returnsListCommandWithNone() throws Exception {
+        ListCommand command = parser.parse("  ");
+        assertEquals(new ListCommand(ListCommand.SortOrder.NONE), command);
+    }
+
+    @Test
+    public void parse_invalidInput_throwsParseException() {
+        assertThrows(ParseException.class, () -> parser.parse("random"));
+    }
+
+    @Test
+    public void parse_validAsc_returnsListCommandAsc() throws Exception {
+        String userInput = PREFIX_SORT + "asc";
+        ListCommand command = parser.parse(userInput);
+        assertEquals(new ListCommand(ListCommand.SortOrder.ASCENDING), command);
+    }
+
+    @Test
+    public void parse_validDesc_returnsListCommandDesc() throws Exception {
+        ListCommand command = parser.parse(PREFIX_SORT + "desc");
+        assertEquals(new ListCommand(ListCommand.SortOrder.DESCENDING), command);
+    }
+
+    @Test
+    public void parse_invalidSortValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> parser.parse(PREFIX_SORT.toString() + "random"));
+    }
+
+    @Test
+    public void parse_extraInputBeforePrefix_throwsParseException() {
+        assertThrows(ParseException.class, () -> parser.parse("extra s/asc"));
+    }
+
+    @Test
+    public void parse_emptySortValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> parser.parse(PREFIX_SORT.toString()));
+    }
+
+}

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -30,28 +30,28 @@ public class TypicalPersons {
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")
             .withEmail("johnd@example.com").withPhone("98765432").withRelationship("Neighbour")
-            .withBirthday("01-01-1990").withNickname("BENNY")
+            .withBirthday("01-01-1990").withNickname("BENNY").withBirthday("02-02-1991")
             .withNotes("Allergic to peanuts").withTags("owesMoney", "friends").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
-            .withEmail("heinz@example.com").withAddress("wall street").build();
+            .withEmail("heinz@example.com").withAddress("wall street").withBirthday("03-03-1992").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
-            .withEmail("cornelia@example.com").withAddress("10th street").withTags("friends").build();
+            .withEmail("cornelia@example.com").withAddress("10th street").withBirthday("04-04-1993").withTags("friends").build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
-            .withEmail("werner@example.com").withAddress("michegan ave").build();
+            .withEmail("werner@example.com").withAddress("michegan ave").withBirthday("05-05-1994").build();
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
             .withEmail("lydia@example.com").withAddress("little tokyo").build();
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
-            .withEmail("anna@example.com").withAddress("4th street").build();
+            .withEmail("anna@example.com").withAddress("4th street").withBirthday("07-07-1996").build();
     public static final Person JOHN = new PersonBuilder().withName("John Guul").withPhone("9482555")
-            .withEmail("john@example.com").withAddress("kazakhstan").build();
+            .withEmail("john@example.com").withAddress("kazakhstan").withBirthday("08-08-1997").build();
     public static final Person JON = new PersonBuilder().withName("Jon Buul").withPhone("9482666")
             .withEmail("jon@example.com").withAddress("yugoslavia").build();
 
     // Manually added
     public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")
-            .withEmail("stefan@example.com").withAddress("little india").build();
+            .withEmail("stefan@example.com").withAddress("little india").withBirthday("09-09-1998").build();
     public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withPhone("8482131")
-            .withEmail("hans@example.com").withAddress("chicago ave").build();
+            .withEmail("hans@example.com").withAddress("chicago ave").withBirthday("13-01-2002").build();
 
     // Manually added - Person's details found in {@code CommandTestUtil}
     public static final Person AMY = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -35,7 +35,8 @@ public class TypicalPersons {
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withAddress("wall street").withBirthday("03-03-1992").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
-            .withEmail("cornelia@example.com").withAddress("10th street").withBirthday("04-04-1993").withTags("friends").build();
+            .withEmail("cornelia@example.com").withAddress("10th street").withBirthday("04-04-1993")
+            .withTags("friends").build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
             .withEmail("werner@example.com").withAddress("michegan ave").withBirthday("05-05-1994").build();
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")


### PR DESCRIPTION
The list command currently only supports displaying persons in their original insertion order. Users have no way of viewing persons based on how soon their birthdays are approaching.

This limits the utility of the list command for tracking closest relative birthday, especially when the address book contains many entries.

Add support for sorting persons by the number of days to their next birthday. Accept 's/asc' and 's/desc' as optional arguments to list command which will sort persons in ascending or descending order of days until their upcoming birthday.

Use MonthDay comparison with today's date to determine. If birthday has already passed this year, treat as occuring in the next year. If user does not provide a sort order, fallback to original insertion order.

This approach ensures that birthdays are treated as recurring yearly events, while preserving the original view when no sorting is specified.