### PR TITLE
Make EditCommand support undo/redo operation

### DIFF
--- a/src/main/java/seedu/address/logic/CommandTracker.java
+++ b/src/main/java/seedu/address/logic/CommandTracker.java
@@ -95,4 +95,12 @@ public class CommandTracker {
         }
         return null;
     }
+    /**
+     * Clears the undo and redo stacks for test hygiene
+     */
+    public void clear() {
+        undoStack.clear();
+        redoStack.clear();
+        wasUndoCalled = false;
+    }
 }


### PR DESCRIPTION
EditCommand currently does not support undo/redo operation. This prevents users from reverting or reapplying changes made during edits, unlike other commands such as 'add' and 'delete' which supports this.

This inconsistency weakens the undo/redo experience and create gaps in reversible operations, especially when multiple commands are chained together.

Let's
- Extend EditCommand to inherit from UndoableCommand
- Track the original and edited Person
- Push the command to CommandTracker
- Implement undo() and redo() operations
- Add necessary test cases to ensure robustness

This resolves #108