### PR TITLE
Fix text wraping and layout alignment

### DIFF
--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -59,7 +59,7 @@ public class PersonCard extends UiPart<Region> {
     public PersonCard(Person person, int displayedIndex) {
         super(FXML);
         this.person = person;
-        id.setText(displayedIndex + ". ");
+        id.setText(String.valueOf(displayedIndex));
         name.setText(person.getName().fullName);
         setTextOrHide(nickname, person.getNickname(), nick -> " (" + nick + ")");
 

--- a/src/main/java/seedu/address/ui/ResultDisplay.java
+++ b/src/main/java/seedu/address/ui/ResultDisplay.java
@@ -24,5 +24,4 @@ public class ResultDisplay extends UiPart<Region> {
         requireNonNull(feedbackToUser);
         resultDisplay.setText(feedbackToUser);
     }
-
 }

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -168,11 +168,14 @@
 
 .cell_relationship_label {
     -fx-text-fill: #0d1117 !important;
-    -fx-background-color: #ff8709;
-    -fx-padding: 1 3 1 3;
-    -fx-border-radius: 2;
-    -fx-background-radius: 2;
-    -fx-font-size: 11;
+    -fx-font-family: "Segoe UI Semibold";
+    -fx-font-weight: bold;
+    -fx-background-color: linear-gradient(to bottom, #ffa733, #ff8709);
+    -fx-padding: 4 8 4 8;
+    -fx-border-radius: 8;
+    -fx-background-radius: 8;
+    -fx-font-size: 12;
+    -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.2), 2, 0, 0, 1);
 }
 
 .stack-pane {
@@ -379,11 +382,14 @@
 
 #tags .label {
     -fx-text-fill: #0d1117;
-    -fx-background-color: #35e118;
-    -fx-padding: 1 3 1 3;
-    -fx-border-radius: 2;
-    -fx-background-radius: 2;
+    -fx-font-family: "Segoe UI";
+    -fx-font-weight: normal;
+    -fx-background-color: linear-gradient(to bottom, #50f04a, #35e118);;
+    -fx-padding: 4 8 4 8;
+    -fx-border-radius: 8;
+    -fx-background-radius: 8;
     -fx-font-size: 11;
+    -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.15), 1.5, 0, 0, 0.5);
 }
 
 .menu-icon {
@@ -393,4 +399,23 @@
 .menu-icon:hover {
     -fx-effect: dropshadow(gaussian, rgba(255, 255, 255, 0.2), 5, 0, 0, 0);
     -fx-opacity: 0.8;
+}
+
+.index_circle {
+    -fx-font-family: "Segoe UI Semibold";
+    -fx-font-size: 13px;
+    -fx-text-fill: white;
+    -fx-font-weight: bold;
+
+    -fx-background-color: linear-gradient(to bottom, #1b2330, #131921);
+    -fx-alignment: center;
+
+    -fx-padding: 6 10 6 10;
+
+    -fx-background-radius: 100;
+    -fx-border-radius: 100;
+
+    -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.3), 2, 0.1, 0, 1);
+    -fx-border-width: 1.5;
+    -fx-border-color: #2d3b4a;
 }

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -192,6 +192,7 @@
     -fx-background-color: #0d1117;
     -fx-border-color: #161b22;
     -fx-border-top-width: 1px;
+    /*-fx-min-height: 100;*/
 }
 
 .status-bar {

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -128,6 +128,9 @@
 
 .list-cell:filled:even {
     -fx-background-color: #161b22;
+    -fx-border-width: 1;
+    -fx-background-radius: 20;
+    -fx-border-radius: 20;
 }
 
 .list-cell:filled:odd {
@@ -136,6 +139,9 @@
 
 .list-cell:filled:selected {
     -fx-background-color: #424242;
+    -fx-border-width: 1;
+    -fx-background-radius: 20;
+    -fx-border-radius: 20;
 }
 
 .list-cell:filled:selected #cardPane {
@@ -345,8 +351,11 @@
 }
 
 #cardPane {
-    -fx-background-color: transparent;
-    -fx-border-width: 0;
+    -fx-border-width: 1;
+    -fx-background-radius: 20;
+    -fx-border-radius: 20;
+    -fx-border-color: #2d3b4a;
+    -fx-padding: 10;
 }
 
 #commandTypeLabel {

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -96,7 +96,7 @@
           </StackPane>
 
           <StackPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="pane-with-border"
-                     minHeight="100" prefHeight="100" maxHeight="100">
+                     minHeight="100" prefHeight="135" maxHeight="140">
             <padding>
               <Insets top="5" right="10" bottom="5" left="10" />
             </padding>

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -10,31 +10,40 @@
 <?import javafx.scene.layout.VBox?>
 
 <HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+
+  <!-- Number Circle -->
+  <VBox alignment="TOP_CENTER">
+      <Label fx:id="id" styleClass="index_circle" >
+        <minWidth>
+          <!-- Ensures that the label text is never truncated -->
+          <Region fx:constant="USE_PREF_SIZE" />
+        </minWidth>
+      </Label>
+  </VBox>
+
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
     </columnConstraints>
     <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
       <padding>
-        <Insets top="5" right="5" bottom="5" left="15" />
+        <Insets top="5" right="5" bottom="5" left="8" />
       </padding>
       <HBox spacing="0.5" alignment="CENTER_LEFT">
-        <Label fx:id="id" styleClass="cell_big_label">
-          <minWidth>
-            <!-- Ensures that the label text is never truncated -->
-            <Region fx:constant="USE_PREF_SIZE" />
-          </minWidth>
-        </Label>
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
         <Label fx:id="nickname" styleClass="cell_nickname_label" text="\$nickname" />
       </HBox>
       <Label fx:id="relationship" styleClass="cell_relationship_label" text="\$relationship" />
       <FlowPane fx:id="tags" />
-      <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
+      <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" >
+        <VBox.margin>
+          <Insets top="2" />
+        </VBox.margin>
+      </Label>
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
       <Label fx:id="birthday" styleClass="cell_small_label" text="\$birthday" />
-      <Label fx:id="notes" styleClass="cell_small_label" text="\$notes" />
+      <Label fx:id="notes" styleClass="cell_small_label" text="\$notes" wrapText="true" />
     </VBox>
   </GridPane>
 </HBox>

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -5,5 +5,5 @@
 
 <StackPane fx:id="placeHolder" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/17"
     xmlns:fx="http://javafx.com/fxml/1">
-  <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display"/>
+  <TextArea fx:id="resultDisplay" editable="false" wrapText="true" styleClass="result-display"/>
 </StackPane>


### PR DESCRIPTION
The ResultDisplay and notes display do not wrap
as expected, causing long text to truncate, overflow. Additionally, the person card layout appears misaligned with spacing issues, between index, name and rest of content.

This affects the visual clarity and consistency of each card, especially when there is long text. Also affects the friendliness of CLI interface as users, need to scroll horizontally to see the full response.

Let's enable proper text wrapping for both ResultDisplay and the notes field to preserve readability. Also, add index badges, to ensure content alignment in person information.

These changes improve the aesthetic quality and usability of the UI. Resolving #97 