### PR TITLE
Add escape character for notes and nickname

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -85,15 +85,6 @@ public class ParserUtil {
         }
         return formattedName.toString().trim();
     }
-    /**
-     * Removes escape characters from the input string.
-     *
-     * @param input The input string.
-     * @return The input string with escape characters removed.
-     */
-    public static String escapeRemover(String input) {
-        return input.replace("\\", "");
-    }
 
     /**
      * Parses a {@code String phone} into a {@code Phone}.
@@ -161,6 +152,7 @@ public class ParserUtil {
         }
         String trimmedNickname = nickname.get().trim();
         try {
+            trimmedNickname = slashEscapeRemover(trimmedNickname);
             Nickname.isValidNickname(trimmedNickname);
         } catch (IllegalArgumentException e) {
             throw new ParseException(e.getMessage());
@@ -182,6 +174,7 @@ public class ParserUtil {
         }
         String trimmedNotes = notes.get().trim();
         try {
+            trimmedNotes = slashEscapeRemover(trimmedNotes);
             Notes.isValidNotes(trimmedNotes);
         } catch (IllegalArgumentException e) {
             throw new ParseException(e.getMessage());
@@ -247,5 +240,25 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+    }
+
+    /**
+     * Removes escape characters from the input string.
+     *
+     * @param input The input string.
+     * @return The input string with escape characters removed.
+     */
+    public static String escapeRemover(String input) {
+        return input.replace("\\", "");
+    }
+
+    /**
+     * Removes escape characters only when they precede a forward slash.
+     *
+     * @param input The input string.
+     * @return The input string with escape characters removed before forward slashes.
+     */
+    public static String slashEscapeRemover(String input) {
+        return input.replace("\\/", "/");
     }
 }

--- a/src/main/java/seedu/address/model/person/Nickname.java
+++ b/src/main/java/seedu/address/model/person/Nickname.java
@@ -7,13 +7,15 @@ import static java.util.Objects.requireNonNull;
  * Guarantees: immutable; is valid as declared in {@link #isValidNickname(String)}
  */
 public class Nickname {
+
     public static final String MESSAGE_CONSTRAINTS_LENGTH =
             "Nicknames should be less than 30 characters long";
     public static final String MESSAGE_CONSTRAINTS_CHARACTERS =
             "Nicknames can only contain printable ASCII characters";
-
     public static final int MAX_LENGTH = 30;
-    public static final String VALIDATION_REGEX = "[^\\s].*";
+
+    // This regex matches only printable ASCII characters (codes 32-126)
+    public static final String VALIDATION_REGEX = "^[\\x20-\\x7E]*$";
 
     public final String nickname;
 
@@ -51,12 +53,10 @@ public class Nickname {
         if (other == this) {
             return true;
         }
-
         // instanceof handles nulls
         if (!(other instanceof Nickname)) {
             return false;
         }
-
         Nickname otherNickname = (Nickname) other;
         return nickname.equals(otherNickname.nickname);
     }

--- a/src/main/java/seedu/address/model/person/Notes.java
+++ b/src/main/java/seedu/address/model/person/Notes.java
@@ -10,8 +10,9 @@ public class Notes {
     public static final String MESSAGE_CONSTRAINTS_LENGTH =
             "Notes can be at most 100 characters long";
     public static final String MESSAGE_CONSTRAINTS_CHARACTERS =
-            "Notes should only contain printable characters";
-    public static final String VALIDATION_REGEX = "[^\\s].*";
+            "Notes can only contain printable ASCII characters";
+    // This regex matches only printable ASCII characters (codes 32-126)
+    public static final String VALIDATION_REGEX = "^[\\x20-\\x7E]*$";
     public static final int MAX_LENGTH = 100;
 
     public final String value;

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -18,15 +18,21 @@ import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NICKNAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTES;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -192,5 +198,41 @@ public class AddCommandParserTest {
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                 + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_escapedPrefixInValue_success() {
+        // Test nickname with escaped prefix
+        Person expectedPerson = new PersonBuilder().withName(VALID_NAME_BOB)
+                .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
+                .withTags(VALID_TAG_FRIEND)
+                .withNickname("Bobby p/h").build();
+        String nicknameWithEscapedPrefix = " " + PREFIX_NICKNAME + "Bobby p\\/h";
+        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
+                + TAG_DESC_FRIEND + nicknameWithEscapedPrefix, new AddCommand(expectedPerson));
+
+        // Test multiple fields with escaped prefixes
+        expectedPerson = new PersonBuilder().withName(VALID_NAME_AMY)
+                .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
+                .withTags(VALID_TAG_FRIEND)
+                .withNickname("Amy e/n")
+                .withNotes("Met at t/conference").build();
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
+                + TAG_DESC_FRIEND + " " + PREFIX_NICKNAME + "Amy e\\/n"
+                + " " + PREFIX_NOTES + "Met at t\\/conference", new AddCommand(expectedPerson));
+    }
+
+    @Test
+    public void parse_escapedBackslashInValue_success() {
+        // Create a person with nickname containing escaped backslashes (not before slash)
+        Person expectedPerson = new PersonBuilder().withName(VALID_NAME_BOB)
+                .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
+                .withTags(VALID_TAG_FRIEND)
+                .withNickname("C:\\\\Users\\\\Bob").build();
+
+        // Command with escaped backslashes that should be preserved
+        String nicknameWithEscapedBackslash = " " + PREFIX_NICKNAME + "C:\\\\Users\\\\Bob";
+        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
+                + TAG_DESC_FRIEND + nicknameWithEscapedBackslash, new AddCommand(expectedPerson));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -255,4 +255,41 @@ public class EditCommandParserTest {
 
         assertEquals("", joinedFields);
     }
+
+    @Test
+    public void parse_escapedPrefixInValue_success() {
+        Index targetIndex = INDEX_FIRST_PERSON;
+
+        // Test nickname with escaped prefix
+        String userInput = targetIndex.getOneBased() + " " + PREFIX_NICKNAME + "John n\\/Wang";
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder()
+                .withNickname("John n/Wang").build();
+        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor, new ArrayList<>());
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // Test multiple fields with escaped prefixes
+        userInput = targetIndex.getOneBased() + " " + PREFIX_NICKNAME + "John n\\/Wang"
+                + " " + PREFIX_NOTES + "Met at n\\/a conference";
+        descriptor = new EditPersonDescriptorBuilder()
+                .withNickname("John n/Wang")
+                .withNotes("Met at n/a conference")
+                .build();
+        expectedCommand = new EditCommand(targetIndex, descriptor, new ArrayList<>());
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_escapedBackslashInValue_success() {
+        Index targetIndex = INDEX_FIRST_PERSON;
+
+        String nicknameWithEscapedBackslash = " " + PREFIX_NICKNAME + "C:\\\\Users\\\\John";
+        String userInput = targetIndex.getOneBased() + nicknameWithEscapedBackslash;
+
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder()
+                .withNickname("C:\\\\Users\\\\John").build();
+        ArrayList<Prefix> toRemoveFields = new ArrayList<>();
+        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor, toRemoveFields);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
 }


### PR DESCRIPTION
fixes #96 

Implemented the escape character for notes and nicknames.

Previously, `edit 1 no/Met at n/a conference`, would change the notes to `Met at` and the name to `a conference`. Now, the user can type `edit 1 no/Met at n\/a conference` to change the notes to `Met at n/a conference`. The same change is made for nickname.

Added some tests for these changes as well.