### PR TITLE
Possibly Unclear Undo Success Message

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -84,6 +84,11 @@ public class AddCommand extends UndoableCommand {
     }
 
     @Override
+    public String getCommandString() {
+        return COMMAND_WORD + " " + toAdd.toCommandSummary();
+    }
+
+    @Override
     public boolean equals(Object other) {
         if (other == this) {
             return true;

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -90,6 +90,18 @@ public class DeleteCommand extends UndoableCommand implements ConfirmableCommand
     }
 
     @Override
+    public String getCommandString() {
+        if (personsToDelete == null || personsToDelete.isEmpty()) {
+            return COMMAND_WORD + " <unknown person(s)>";
+        }
+
+        String summary = personsToDelete.stream()
+                .map(Person::toCommandSummary)
+                .collect(Collectors.joining(", "));
+        return COMMAND_WORD + " " + summary;
+    }
+
+    @Override
     public boolean equals(Object other) {
         if (other == this) {
             return true;

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -129,7 +129,12 @@ public class EditCommand extends UndoableCommand {
 
     @Override
     public String getCommandString() {
-        return COMMAND_WORD + " " + personToEdit.toCommandSummary();
+        return String.format("%s %d: %s -> %s",
+                COMMAND_WORD,
+                index.getOneBased(),
+                personToEdit.toCommandSummary(),
+                editedPerson.toCommandSummary()
+        );
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -126,6 +126,12 @@ public class EditCommand extends UndoableCommand {
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
+
+    @Override
+    public String getCommandString() {
+        return COMMAND_WORD + " " + personToEdit.toCommandSummary();
+    }
+
     /**
      * Creates and returns a {@code Person} with the details of {@code personToEdit}
      * edited with {@code editPersonDescriptor}.

--- a/src/main/java/seedu/address/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RedoCommand.java
@@ -14,7 +14,7 @@ public class RedoCommand extends Command {
             + ": Redoes the most recent command entered by the user.\n"
             + "Example: " + COMMAND_WORD;
 
-    public static final String MESSAGE_REDO_SUCCESS = "Redo successful!";
+    public static final String MESSAGE_REDO_SUCCESS = "Redo successful! Re-did Command: ";
 
     public static final String MESSAGE_FAILURE = "Nothing to redo!";
 
@@ -27,7 +27,8 @@ public class RedoCommand extends Command {
         }
 
         lastCommand.redo(model);
-        return new CommandResult(MESSAGE_REDO_SUCCESS);
+        String redidCommand = lastCommand.getCommandString();
+        return new CommandResult(MESSAGE_REDO_SUCCESS + redidCommand);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -14,7 +14,7 @@ public class UndoCommand extends Command {
             + ": Undoes the most recent command entered by the user.\n"
             + "Example: " + COMMAND_WORD;
 
-    public static final String MESSAGE_UNDO_SUCCESS = "Undo successful!";
+    public static final String MESSAGE_UNDO_SUCCESS = "Undo successful! Reverted Command: ";
 
     public static final String MESSAGE_NO_UNDO_FAILURE = "Nothing to undo!";
 
@@ -33,7 +33,8 @@ public class UndoCommand extends Command {
         }
 
         lastCommand.undo(model);
-        return new CommandResult(MESSAGE_UNDO_SUCCESS);
+        String undoneCommand = lastCommand.getCommandString();
+        return new CommandResult(MESSAGE_UNDO_SUCCESS + undoneCommand);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/UndoableCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoableCommand.java
@@ -15,4 +15,9 @@ public abstract class UndoableCommand extends Command {
      * Redoes the last undone command.
      */
     public abstract void redo(Model model);
+
+    /**
+     * Gets the command string of the executed command.
+     */
+    public abstract String getCommandString();
 }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -1,6 +1,15 @@
 package seedu.address.model.person;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NICKNAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTES;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_RELATIONSHIP;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -142,6 +151,15 @@ public class Person {
         // use this method for custom fields hashing instead of implementing your own
         return Objects.hash(name, phone, email, address, birthday, relationship,
                             nickname, notes, tags);
+    }
+
+    /**
+     * Returns the summary of the person that a command was called upon.
+     *
+     * @return The command summary of the person.
+     */
+    public String toCommandSummary() {
+        return String.format("%s (%s)", name, email);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -150,7 +150,7 @@ public class Person {
      * @return The command summary of the person.
      */
     public String toCommandSummary() {
-        return String.format("%s (%s)", name, email);
+        return String.format("%s", name);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -1,15 +1,6 @@
 package seedu.address.model.person;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NICKNAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTES;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_RELATIONSHIP;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Collections;
 import java.util.HashSet;

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -97,6 +97,13 @@ public class AddCommandTest {
     }
 
     @Test
+    public void getCommandStringMethod() {
+        AddCommand addCommand = new AddCommand(ALICE);
+        String expected = String.format("add %s (%s)", ALICE.getName(), ALICE.getEmail());
+        assertEquals(expected, addCommand.getCommandString());
+    }
+
+    @Test
     public void toStringMethod() {
         AddCommand addCommand = new AddCommand(ALICE);
         String expected = AddCommand.class.getCanonicalName() + "{toAdd=" + ALICE + "}";

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -99,7 +99,7 @@ public class AddCommandTest {
     @Test
     public void getCommandStringMethod() {
         AddCommand addCommand = new AddCommand(ALICE);
-        String expected = String.format("add %s (%s)", ALICE.getName(), ALICE.getEmail());
+        String expected = String.format("add %s", ALICE.getName());
         assertEquals(expected, addCommand.getCommandString());
     }
 

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -183,9 +183,17 @@ public class DeleteCommandTest {
     }
 
     @Test
-    public void getCommandStringMethod() {
+    public void getCommandStringMethod_invalidPersons_returnsUnsuccessfulSummary() {
         DeleteCommand deleteCommand = new DeleteCommand(List.of(INDEX_FIRST_PERSON));
         String expected = String.format("delete <unknown person(s)>");
+        assertEquals(expected, deleteCommand.getCommandString());
+    }
+
+    @Test
+    public void getCommandString_nonEmptyPersons_returnsSuccessfulSummary() throws CommandException {
+        DeleteCommand deleteCommand = new DeleteCommand(List.of(INDEX_FIRST_PERSON));
+        deleteCommand.execute(model);
+        String expected = String.format("delete Alice Pauline");
         assertEquals(expected, deleteCommand.getCommandString());
     }
 

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.List;
@@ -180,6 +181,13 @@ public class DeleteCommandTest {
 
         // multiple vs single -> returns false
         assertNotEquals(deleteFirstCommand, deleteMultipleCommand);
+    }
+
+    @Test
+    public void getCommandStringMethod() {
+        DeleteCommand deleteCommand = new DeleteCommand(List.of(INDEX_FIRST_PERSON));
+        String expected = String.format("delete <unknown person(s)>");
+        assertEquals(expected, deleteCommand.getCommandString());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -8,7 +8,6 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
-import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.List;

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -21,6 +21,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTES;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_RELATIONSHIP;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.ArrayList;
@@ -336,6 +337,34 @@ public class EditCommandTest {
 
         // different descriptor -> returns false
         assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_PERSON, DESC_BOB, new ArrayList<>())));
+    }
+
+    @Test
+    public void getCommandString_returnsCorrectUndoMessage() throws Exception {
+        // Arrange: Original and edited person
+        Person original = new PersonBuilder()
+                .withName("Alice Pauline")
+                .withEmail("alice@example.com")
+                .build();
+
+        Person edited = new PersonBuilder(original)
+                .withName("Bob Tan")
+                .withEmail("bob@example.com")
+                .build();
+
+        EditCommand.EditPersonDescriptor descriptor = new EditCommand.EditPersonDescriptor();
+        descriptor.setName(edited.getName());
+        descriptor.setEmail(edited.getEmail());
+
+        EditCommand editCommand = new EditCommand(Index.fromZeroBased(0), descriptor, new ArrayList<>());
+
+        Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new CommandHistory());
+        model.setPerson(model.getFilteredPersonList().get(0), original); // overwrite with known person
+
+        editCommand.execute(model);
+
+        String expected = String.format("edit %s (%s)", ALICE.getName(), ALICE.getEmail());
+        assertEquals(expected, editCommand.getCommandString());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -22,6 +22,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_RELATIONSHIP;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BOB;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.ArrayList;
@@ -348,7 +349,7 @@ public class EditCommandTest {
                 .build();
 
         Person edited = new PersonBuilder(original)
-                .withName("Bob Tan")
+                .withName("Bob Choo")
                 .withEmail("bob@example.com")
                 .build();
 
@@ -363,7 +364,7 @@ public class EditCommandTest {
 
         editCommand.execute(model);
 
-        String expected = String.format("edit %s (%s)", ALICE.getName(), ALICE.getEmail());
+        String expected = String.format("edit 1: %s -> %s", ALICE.getName(), BOB.getName());
         assertEquals(expected, editCommand.getCommandString());
     }
 

--- a/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
@@ -42,7 +42,7 @@ public class RedoCommandTest {
         commandTracker.popUndo();
 
         RedoCommand redoCommand = new RedoCommand();
-        String expectedMessage = "Redo successful!";
+        String expectedMessage = "Redo successful! Re-did Command: add MockPerson";
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), new CommandHistory());
         assertCommandSuccess(redoCommand, model, expectedMessage, expectedModel);
@@ -87,5 +87,10 @@ public class RedoCommandTest {
 
         @Override
         public void redo(Model model) { }
+
+        @Override
+        public String getCommandString() {
+            return "add MockPerson";
+        }
     }
 }

--- a/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
@@ -33,7 +33,7 @@ public class UndoCommandTest {
         commandTracker.push(mockCommand);
 
         UndoCommand undoCommand = new UndoCommand();
-        String expectedMessage = "Undo successful!";
+        String expectedMessage = "Undo successful! Reverted Command: add MockPerson";
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), new CommandHistory());
         assertCommandSuccess(undoCommand, model, expectedMessage, expectedModel);
@@ -78,5 +78,10 @@ public class UndoCommandTest {
 
         @Override
         public void redo(Model model) { }
+
+        @Override
+        public String getCommandString() {
+            return "add MockPerson";
+        }
     }
 }

--- a/src/test/java/seedu/address/model/person/NameSimilarPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameSimilarPredicateTest.java
@@ -1,0 +1,46 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.person.namepredicate.NameSimilarPredicate;
+
+public class NameSimilarPredicateTest {
+
+    @Test
+    public void equals_sameObject_returnsTrue() {
+        NameSimilarPredicate predicate = new NameSimilarPredicate(List.of("Alice", "Bob"));
+        assertTrue(predicate.equals(predicate));
+    }
+
+    @Test
+    public void equals_equalKeywords_returnsTrue() {
+        NameSimilarPredicate predicate1 = new NameSimilarPredicate(List.of("Alice", "Bob"));
+        NameSimilarPredicate predicate2 = new NameSimilarPredicate(List.of("Alice", "Bob"));
+        assertTrue(predicate1.equals(predicate2));
+    }
+
+    @Test
+    public void equals_differentKeywords_returnsFalse() {
+        NameSimilarPredicate predicate1 = new NameSimilarPredicate(List.of("Alice"));
+        NameSimilarPredicate predicate2 = new NameSimilarPredicate(List.of("Bob"));
+        assertFalse(predicate1.equals(predicate2));
+    }
+
+    @Test
+    public void equals_null_returnsFalse() {
+        NameSimilarPredicate predicate = new NameSimilarPredicate(List.of("Alice"));
+        assertFalse(predicate.equals(null));
+    }
+
+    @Test
+    public void equals_differentType_returnsFalse() {
+        NameSimilarPredicate predicate = new NameSimilarPredicate(List.of("Alice"));
+        assertFalse(predicate.equals("NotAPredicate"));
+    }
+}
+


### PR DESCRIPTION
As stated in the issue, "The undo success message is the same for every successful undo".

This PR changes the undo/redo messages to be a bit more useful to the CLI user.
What the changes entail:
- Nicer message
- Message with clear outcome on which command was undone/redone
- Summary on which outcome was undone/redone

What the changes DO NOT entail:
- ```Edit``` does not show new person info i.e. if Alice was renamed to Bob, the success message does not cover this

Example on ```Add```
![image](https://github.com/user-attachments/assets/6917b115-b45e-4d6d-97eb-12c577d8698a)
![image](https://github.com/user-attachments/assets/3254a968-c529-46fe-895e-5f7ca783987f)

Example on ```Delete```
![image](https://github.com/user-attachments/assets/04acd0ae-353d-434d-a69d-fe827372ff45)
![image](https://github.com/user-attachments/assets/94f34702-872f-44fc-830c-7bd9f63eaa2c)

Example on ```Edit``` ***
![image](https://github.com/user-attachments/assets/a6fefc86-f736-40a7-ab03-260d4cf733af)
![image](https://github.com/user-attachments/assets/89e6cd5e-c670-45dd-abe5-f2fef4eec643)

fixes #122
