### PR TITLE
Undo does not restore the original order in the displayed list 

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -40,6 +40,8 @@ public class DeleteCommand extends UndoableCommand implements ConfirmableCommand
 
     private List<Person> personsToDelete;
 
+    private List<Integer> originalIndices;
+
     public DeleteCommand(List<Index> targetIndices) {
         this.targetIndices = targetIndices;
     }
@@ -61,6 +63,10 @@ public class DeleteCommand extends UndoableCommand implements ConfirmableCommand
                 .map(targetIndex -> lastShownList.get(targetIndex.getZeroBased()))
                 .toList();
 
+        originalIndices = targetIndices.stream()
+                .map(Index::getZeroBased)
+                .toList();
+
         return new CommandResult(String.format(MESSAGE_CONFIRM_DELETE,
                 personsToDelete.stream()
                         .map(person -> person.getName().toString())
@@ -71,9 +77,11 @@ public class DeleteCommand extends UndoableCommand implements ConfirmableCommand
     public void undo(Model model) {
         requireNonNull(model);
         if (personsToDelete != null) {
-            for (Person person : personsToDelete) {
+            for (int i = 0; i < personsToDelete.size(); i++) {
+                Person person = personsToDelete.get(i);
+                int originalIndex = originalIndices.get(i);
                 if (!model.hasPerson(person)) {
-                    model.addPerson(person);
+                    model.addPersonAt(person, originalIndex);
                 }
             }
         }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -57,6 +57,10 @@ public class AddressBook implements ReadOnlyAddressBook {
         setPersons(newData.getPersonList());
     }
 
+    public void addPersonAt(Person person, int index) {
+        persons.addAt(person, index);
+    }
+
     //// person-level operations
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -101,4 +101,6 @@ public interface Model {
      * @throws NullPointerException if {@code comparator} is null.
      */
     void sortFilteredPersonList(Comparator<Person> comparator);
+
+    void addPersonAt(Person person, int index);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -159,6 +159,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void addPersonAt(Person person, int index) {
+        addressBook.addPersonAt(person, index);
+        updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+    }
+
+    @Override
     public boolean equals(Object other) {
         if (other == this) {
             return true;

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -147,4 +147,18 @@ public class UniquePersonList implements Iterable<Person> {
         }
         return true;
     }
+
+    /**
+     * Adds a person at the specified index.
+     *
+     * @param toAdd The person that needs to be added.
+     * @param index The index to insert the person at.
+     */
+    public void addAt(Person toAdd, int index) {
+        requireNonNull(toAdd);
+        if (contains(toAdd)) {
+            throw new DuplicatePersonException();
+        }
+        internalList.add(index, toAdd);
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -143,6 +143,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void addPersonAt(Person addPerson, int index) {
+
+        }
+
+        @Override
         public void setAddressBook(ReadOnlyAddressBook newData) {
             throw new AssertionError("This method should not be called.");
         }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/743c53c4-aab3-485a-8349-13d9dc5568e7)

As mentioned, this can be a feature flaw as deleting an entry does not restore its original index.
The changes in this commit (ignore the name as i forgot to add 2 commits) should restore the original order of the deleted persons.

Please double check the jar file I sent to our telechat before merging this in.

fixes #141 