### PR TITLE
Update UNKNOWN_COMMAND message for better clarity

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -13,7 +13,7 @@ import seedu.address.model.tag.Tag;
  */
 public class Messages {
 
-    public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command, try typing help for assistance!";
+    public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command, try typing 'help' for assistance!";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -13,7 +13,7 @@ import seedu.address.model.tag.Tag;
  */
 public class Messages {
 
-    public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
+    public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command, try typing help for assistance!";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";


### PR DESCRIPTION
As per the relevant issue, update MESSAGE_UNKNOWN_COMMAND for better clarity. This can help users immediately find further assistance if they are unsure on what commands to use.

As per this PR, the message now prints: `Unknown command, try typing 'help' for assistance!`.

Fixes #182 