### PR TITLE
Fix undo after clear

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import seedu.address.logic.CommandTracker;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 
@@ -12,7 +13,9 @@ public class ClearCommand extends Command implements ConfirmableCommand {
 
     public static final String COMMAND_WORD = "clear";
     public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
-    public static final String MESSAGE_CONFIRMATION = "Are you sure you want to clear the address book? (y/n)";
+    public static final String MESSAGE_CONFIRMATION = "This is an undoable command. "
+            + "The entries in the address book will be lost permanently."
+            + "Are you sure you want to clear the address book? (y/n)";
     public static final String ABORTION_SUCCESS = "Clear aborted";
 
     @Override
@@ -31,6 +34,8 @@ public class ClearCommand extends Command implements ConfirmableCommand {
     public CommandResult executeConfirmed(Model model) {
         requireNonNull(model);
         model.setAddressBook(new AddressBook());
+        CommandTracker tracker = CommandTracker.getInstance();
+        tracker.clear();
         return new CommandResult(MESSAGE_SUCCESS);
     }
 

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -1,5 +1,8 @@
 package seedu.address.logic.commands;
 
+import java.util.logging.Logger;
+
+import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.CommandTracker;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -18,17 +21,19 @@ public class UndoCommand extends Command {
 
     public static final String MESSAGE_NO_UNDO_FAILURE = "Nothing to undo!";
 
+    private final Logger logger = LogsCenter.getLogger(DeleteCommand.class);
+
     @Override
     public CommandResult execute(Model model) throws CommandException {
         CommandTracker tracker = CommandTracker.getInstance();
-
         if (!tracker.canUndo()) {
+            logger.info("Cannot undo, empty undo stack");
             throw new CommandException(MESSAGE_NO_UNDO_FAILURE);
         }
 
         UndoableCommand lastCommand = (UndoableCommand) tracker.popUndo();
-
         if (lastCommand == null) {
+            logger.info("Cannot undo, lastCommand is null");
             throw new CommandException(MESSAGE_NO_UNDO_FAILURE);
         }
 


### PR DESCRIPTION
As appeared in #162

Fixes #162

Now ```clear``` clears the undo and redo stack. ```clear``` warns the user that ```clear``` is undoable and data will be permanently lost. Undoing after ```clear``` raises appropriate error message.

