### PR TITLE
Allow invalid commands in command history

### DIFF
--- a/src/main/java/seedu/address/model/CommandHistory.java
+++ b/src/main/java/seedu/address/model/CommandHistory.java
@@ -110,6 +110,11 @@ public class CommandHistory implements ReadOnlyCommandHistory {
     }
 
     @Override
+    public void setIndex(int index) {
+        this.currentIndex = index;
+    }
+
+    @Override
     public boolean canNavigateBackward() {
         return this.currentIndex < commandList.size();
     }

--- a/src/main/java/seedu/address/model/ReadOnlyCommandHistory.java
+++ b/src/main/java/seedu/address/model/ReadOnlyCommandHistory.java
@@ -27,6 +27,11 @@ public interface ReadOnlyCommandHistory {
     void resetNavigation();
 
     /**
+     * Set the navigation position in the command history.
+     */
+    void setIndex(int index);
+
+    /**
      * Returns true if there are previous commands to navigate to.
      */
     boolean canNavigateBackward();

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -75,11 +75,12 @@ public class CommandBox extends UiPart<Region> {
 
         try {
             commandExecutor.execute(commandText);
+            commandTextField.setText("");
         } catch (CommandException | ParseException e) {
             setStyleToIndicateCommandFailure();
         } finally {
             commandHistory.resetNavigation();
-            commandTextField.setText("");
+            commandHistory.setIndex(1);
         }
     }
 

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -75,10 +75,11 @@ public class CommandBox extends UiPart<Region> {
 
         try {
             commandExecutor.execute(commandText);
-            commandHistory.resetNavigation();
-            commandTextField.setText("");
         } catch (CommandException | ParseException e) {
             setStyleToIndicateCommandFailure();
+        } finally {
+            commandHistory.resetNavigation();
+            commandTextField.setText("");
         }
     }
 


### PR DESCRIPTION
fixes #196 

Refer to the issue for more information. The command history now stores both valid and invalid commands. The terminal is not cleared for invalid commands.