### PR TITLE
Fix UI issue where name is squashed

### DIFF
--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -33,10 +33,8 @@
         <Insets top="5" right="5" bottom="5" left="8" />
       </padding>
       <HBox spacing="5" alignment="CENTER_LEFT">
-        <Label fx:id="name" text="\$first" styleClass="cell_big_label" wrapText="true"/>
-        <Label fx:id="nickname" styleClass="cell_nickname_label" text="\$nickname" wrapText="true">
-          <minWidth>100</minWidth>
-        </Label>
+        <Label fx:id="name" text="\$first" styleClass="cell_big_label" wrapText="true" />
+        <Label fx:id="nickname" text="\$nickname" styleClass="cell_nickname_label" wrapText="true" minWidth="50" maxWidth="200"/>
       </HBox>
       <Label fx:id="relationship" styleClass="cell_relationship_label" text="\$relationship" />
       <FlowPane fx:id="tags" />


### PR DESCRIPTION
fixes #285
Fixed a small UI issue where the name would be squashed when the nickname is long.

Before:
<img width="481" alt="Screenshot 2025-04-07 at 11 18 40 AM" src="https://github.com/user-attachments/assets/abdda0e5-edee-49d5-992f-d71daaf3d246" />

After:
<img width="537" alt="Screenshot 2025-04-07 at 11 19 09 AM" src="https://github.com/user-attachments/assets/d54db2d4-1845-46e5-9e1c-038d06caa398" />
