### PR TITLE
Fix usage of escape character in name

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -103,7 +103,7 @@ Format: `add n/NAME p/[PHONE_NUMBER] e/[EMAIL] a/[ADDRESS] [r/RELATIONSHIP] [nn/
 
 #### Name Requirements
 ✔ **Must start with a letter** (A-Z, a-z)  
-✔ **Cannot end with a special character** (@, ., -, etc.)  
+✔ **Cannot end with a special character** (`@`, `.`, `,`, `!`, `'`, `/`, `-`, and `?`) <br>
 ✔ **No consecutive special characters** (e.g. `--`, `@@`, `..`)
 
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -55,7 +55,7 @@ public class ParserUtil {
         requireNonNull(name);
         String input = name.trim();
         String formattedName = formatName(input);
-        formattedName = escapeRemover(formattedName);
+        formattedName = slashEscapeRemover(formattedName);
         try {
             Name.isValidName(formattedName);
         } catch (IllegalArgumentException e) {
@@ -312,17 +312,6 @@ public class ParserUtil {
         }
 
         return Optional.of(new ImagePath(trimmed));
-    }
-
-
-    /**
-     * Removes escape characters from the input string.
-     *
-     * @param input The input string.
-     * @return The input string with escape characters removed.
-     */
-    public static String escapeRemover(String input) {
-        return input.replace("\\", "");
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -21,7 +21,7 @@ public class Name {
      * otherwise " " (a blank string) becomes a valid input.
      */
     public static final String VALIDATION_REGEX =
-            "^[\\p{L}][\\p{L}0-9 ]*(?:[@.,!'/\\\\-][\\p{L}0-9 ]+)*$";
+            "^[\\p{L}][\\p{L}0-9 ]*(?:[@.,!'/-][\\p{L}0-9 ]+)*$";
 
     public final String fullName;
 


### PR DESCRIPTION
fixes #289 

Now, backslashes are only accepted in names when they come before a forward slash. Adjusted the regex to disallow back slashes.

Will update the warning on backslashes in the UG in another pr, when I add the table of field requirements.